### PR TITLE
fix: mapPrivatePropertiesAndMethod should not be mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [GH#11](https://github.com/jolicode/automapper/pull/11) Added phpstan level 5 in CI
+- [GH#9](https://github.com/jolicode/automapper/pull/9) fix: `mapPrivatePropertiesAndMethod` should not be mandatory
 
 ## [8.0.1] - 2023-10-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [GH#11](https://github.com/jolicode/automapper/pull/11) Added phpstan level 5 in CI
+
+### Fixed
 - [GH#9](https://github.com/jolicode/automapper/pull/9) fix: `mapPrivatePropertiesAndMethod` should not be mandatory
 
 ## [8.0.1] - 2023-10-04

--- a/src/Extractor/FromSourceMappingExtractor.php
+++ b/src/Extractor/FromSourceMappingExtractor.php
@@ -87,7 +87,7 @@ final class FromSourceMappingExtractor extends MappingExtractor
                 $this->getMaxDepth($mapperMetadata->getSource(), $property),
                 $this->isIgnoredProperty($mapperMetadata->getSource(), $property),
                 $this->isIgnoredProperty($mapperMetadata->getTarget(), $property),
-                PropertyReadInfo::VISIBILITY_PUBLIC === ($this->readInfoExtractor->getReadInfo($mapperMetadata->getSource(), $property)?->getVisibility() ?? true)
+                PropertyReadInfo::VISIBILITY_PUBLIC === ($this->readInfoExtractor->getReadInfo($mapperMetadata->getSource(), $property)?->getVisibility() ?? PropertyReadInfo::VISIBILITY_PUBLIC),
             );
         }
 

--- a/src/Extractor/FromTargetMappingExtractor.php
+++ b/src/Extractor/FromTargetMappingExtractor.php
@@ -86,7 +86,7 @@ final class FromTargetMappingExtractor extends MappingExtractor
                 $this->getMaxDepth($mapperMetadata->getTarget(), $property),
                 $this->isIgnoredProperty($mapperMetadata->getSource(), $property),
                 $this->isIgnoredProperty($mapperMetadata->getTarget(), $property),
-                PropertyReadInfo::VISIBILITY_PUBLIC === ($this->readInfoExtractor->getReadInfo($mapperMetadata->getSource(), $property)?->getVisibility() ?? true),
+                PropertyReadInfo::VISIBILITY_PUBLIC === ($this->readInfoExtractor->getReadInfo($mapperMetadata->getSource(), $property)?->getVisibility() ?? PropertyReadInfo::VISIBILITY_PUBLIC),
             );
         }
 

--- a/src/Extractor/SourceTargetMappingExtractor.php
+++ b/src/Extractor/SourceTargetMappingExtractor.php
@@ -79,7 +79,7 @@ class SourceTargetMappingExtractor extends MappingExtractor
                     $maxDepth,
                     $this->isIgnoredProperty($mapperMetadata->getSource(), $property),
                     $this->isIgnoredProperty($mapperMetadata->getTarget(), $property),
-                    PropertyReadInfo::VISIBILITY_PUBLIC === ($this->readInfoExtractor->getReadInfo($mapperMetadata->getSource(), $property)?->getVisibility() ?? true),
+                    PropertyReadInfo::VISIBILITY_PUBLIC === ($this->readInfoExtractor->getReadInfo($mapperMetadata->getSource(), $property)?->getVisibility() ?? PropertyReadInfo::VISIBILITY_PUBLIC),
                 );
             }
         }

--- a/src/MapperMetadata.php
+++ b/src/MapperMetadata.php
@@ -229,7 +229,8 @@ class MapperMetadata implements MapperGeneratorMetadataInterface
                 null,
                 new CallbackTransformer($property),
                 $property,
-                false
+                false,
+                isPublic: true,
             );
         }
     }

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -93,7 +93,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testAutoMapperFromArrayCustomDateTime(): void
     {
-        $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true, classPrefix: 'CustomDateTime_');
+        $this->buildAutoMapper(classPrefix: 'CustomDateTime_');
 
         $dateTime = \DateTime::createFromFormat(\DateTime::RFC3339, '1987-04-30T06:00:00Z');
         $customFormat = 'U';
@@ -581,6 +581,8 @@ class AutoMapperTest extends AutoMapperBaseTest
         $address->setCity('some city');
         $user->setAddress($address);
 
+        $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true);
+
         /** @var Fixtures\UserDTO $userDto */
         $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class, [MapperContext::ALLOWED_ATTRIBUTES => ['id', 'age', 'address']]);
 
@@ -615,6 +617,7 @@ class AutoMapperTest extends AutoMapperBaseTest
         });
 
         $user = new Fixtures\User(1, 'yolo', '13');
+
         $userDto = $this->autoMapper->map($user, Fixtures\UserDTOMerged::class);
 
         self::assertArrayHasKey('name', $userDto->getProperties());


### PR DESCRIPTION
`mapPrivatePropertiesAndMethod` machanism was buggy, this is now fixed