### PR TITLE
Use PhpStanExtractor instead of PhpDocExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GH#10](https://github.com/jolicode/automapper/pull/10) Introduce custom transformers
 - [GH#26](https://github.com/jolicode/automapper/pull/26) Fix mappings involving DateTimeInterface type
 
+### Changed
+- [GH#27](https://github.com/jolicode/automapper/pull/27) Use PhpStanExtractor instead of PhpDocExtractor
+
 ## [8.1.0] - 2023-12-14
 ### Added
 - [GH#22](https://github.com/jolicode/automapper/pull/22) Added generic AST extractor

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require-dev": {
         "doctrine/annotations": "~1.0",
         "moneyphp/money": "^3.0",
-        "phpdocumentor/reflection-docblock": "^3.0 || ^4.0 || ^5.0",
+        "phpdocumentor/type-resolver": "^1.7",
+        "phpstan/phpdoc-parser": "^1.24",
         "phpunit/phpunit": "^8.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",

--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -28,7 +28,7 @@ use AutoMapper\Transformer\TransformerFactoryInterface;
 use AutoMapper\Transformer\UniqueTypeTransformerFactory;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PhpParser\ParserFactory;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
@@ -190,10 +190,10 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
 
         $reflectionExtractor = new ReflectionExtractor(accessFlags: $flags);
 
-        $phpDocExtractor = new PhpDocExtractor();
+        $phpStanExtractor = new PhpStanExtractor();
         $propertyInfoExtractor = new PropertyInfoExtractor(
             [$reflectionExtractor],
-            [$phpDocExtractor, $reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
             [$reflectionExtractor],
             [new MapToContextPropertyInfoExtractorDecorator($reflectionExtractor)]
         );

--- a/tests/Extractor/FromSourceMappingExtractorTest.php
+++ b/tests/Extractor/FromSourceMappingExtractorTest.php
@@ -19,7 +19,7 @@ use AutoMapper\Transformer\MultipleTransformerFactory;
 use AutoMapper\Transformer\NullableTransformerFactory;
 use AutoMapper\Transformer\ObjectTransformerFactory;
 use AutoMapper\Transformer\UniqueTypeTransformerFactory;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -50,10 +50,10 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
         $reflectionExtractor = new ReflectionExtractor(null, null, null, true, $flags);
         $transformerFactory = new ChainTransformerFactory();
 
-        $phpDocExtractor = new PhpDocExtractor();
+        $phpStanExtractor = new PhpStanExtractor();
         $propertyInfoExtractor = new PropertyInfoExtractor(
             [$reflectionExtractor],
-            [$phpDocExtractor, $reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
             [$reflectionExtractor],
             [$reflectionExtractor]
         );

--- a/tests/Extractor/FromTargetMappingExtractorTest.php
+++ b/tests/Extractor/FromTargetMappingExtractorTest.php
@@ -18,7 +18,7 @@ use AutoMapper\Transformer\MultipleTransformerFactory;
 use AutoMapper\Transformer\NullableTransformerFactory;
 use AutoMapper\Transformer\ObjectTransformerFactory;
 use AutoMapper\Transformer\UniqueTypeTransformerFactory;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -48,10 +48,10 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
 
         $reflectionExtractor = new ReflectionExtractor(null, null, null, true, $flags);
 
-        $phpDocExtractor = new PhpDocExtractor();
+        $phpStanExtractor = new PhpStanExtractor();
         $propertyInfoExtractor = new PropertyInfoExtractor(
             [$reflectionExtractor],
-            [$phpDocExtractor, $reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
             [$reflectionExtractor],
             [$reflectionExtractor]
         );

--- a/tests/MapperGeneratorMetadataFactoryTest.php
+++ b/tests/MapperGeneratorMetadataFactoryTest.php
@@ -19,7 +19,7 @@ use AutoMapper\Transformer\MultipleTransformerFactory;
 use AutoMapper\Transformer\NullableTransformerFactory;
 use AutoMapper\Transformer\ObjectTransformerFactory;
 use AutoMapper\Transformer\UniqueTypeTransformerFactory;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -40,10 +40,10 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
         $customTransformerRegistry = new CustomTransformersRegistry();
         $reflectionExtractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE);
 
-        $phpDocExtractor = new PhpDocExtractor();
+        $phpStanExtractor = new PhpStanExtractor();
         $propertyInfoExtractor = new PropertyInfoExtractor(
             [$reflectionExtractor],
-            [$phpDocExtractor, $reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
             [$reflectionExtractor],
             [$reflectionExtractor]
         );


### PR DESCRIPTION
Because it's the default extractor in Symfony nowadays.