### PR TITLE
minor: add phpDoc in mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GH#25](https://github.com/jolicode/automapper/pull/25) Pass full input object to property custom transformers
 - [GH#10](https://github.com/jolicode/automapper/pull/10) Introduce custom transformers
 - [GH#26](https://github.com/jolicode/automapper/pull/26) Fix mappings involving DateTimeInterface type
+- [GH#37](https://github.com/jolicode/automapper/pull/37) Adds useful phpDoc annotation in generated mappers
 
 ### Fixed
 - [GH#33](https://github.com/jolicode/automapper/pull/33) Allow usage of imported class names in custom transformers

--- a/src/Generator/MapMethodStatementsGenerator.php
+++ b/src/Generator/MapMethodStatementsGenerator.php
@@ -10,6 +10,7 @@ use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
 use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
 use AutoMapper\MapperContext;
 use AutoMapper\MapperGeneratorMetadataInterface;
+use PhpParser\Comment;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -219,7 +220,8 @@ final readonly class MapMethodStatementsGenerator
             new Expr\Assign(
                 $variableRegistry->getResult(),
                 new Expr\BinaryOp\Coalesce($targetToPopulate, new Expr\ConstFetch(new Name('null')))
-            )
+            ),
+            ['comments' => [new Comment(sprintf('/** @var %s $result */', $mapperMetadata->getTarget() === 'array' ? $mapperMetadata->getTarget() : '\\' . $mapperMetadata->getTarget()))]]
         );
 
         if (!$this->allowReadOnlyTargetToPopulate && $mapperMetadata->isTargetReadOnlyClass()) {

--- a/src/Generator/MapperGenerator.php
+++ b/src/Generator/MapperGenerator.php
@@ -108,6 +108,13 @@ final readonly class MapperGenerator
             ->addParam(new Param($variableRegistry->getSourceInput()))
             ->addParam(new Param($variableRegistry->getContext(), default: new Expr\Array_(), type: 'array'))
             ->addStmts($this->mapMethodStatementsGenerator->getStatements($mapperMetadata))
+            ->setDocComment(
+                sprintf(
+                    '/** @param %s $%s */',
+                    $mapperMetadata->getSource() === 'array' ? $mapperMetadata->getSource() : '\\' . $mapperMetadata->getSource(),
+                    'value'
+                )
+            )
             ->getNode();
     }
 
@@ -129,7 +136,12 @@ final readonly class MapperGenerator
         return (new Builder\Method('injectMappers'))
             ->makePublic()
             ->setReturnType('void')
-            ->addParam(new Param(var: $param = new Expr\Variable('autoMapperRegistry'), type: AutoMapperRegistryInterface::class))
+            ->addParam(
+                new Param(
+                    var: $param = new Expr\Variable('autoMapperRegistry'),
+                    type: AutoMapperRegistryInterface::class
+                )
+            )
             ->addStmts($this->injectMapperMethodStatementsGenerator->getStatements($param, $mapperMetadata))
             ->getNode();
     }

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -50,7 +50,7 @@ class AutoMapperTest extends AutoMapperBaseTest
             return ((int) date('Y')) - ((int) $user->age);
         });
 
-        $address = new Fixtures\Address();
+        $address = new Address();
         $address->setCity('Toulon');
         $user = new Fixtures\User(1, 'yolo', '13');
         $user->address = $address;
@@ -66,8 +66,8 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertSame(13, $userDto->age);
         self::assertSame(((int) date('Y')) - 13, $userDto->yearOfBirth);
         self::assertCount(1, $userDto->addresses);
-        self::assertInstanceOf(Fixtures\AddressDTO::class, $userDto->address);
-        self::assertInstanceOf(Fixtures\AddressDTO::class, $userDto->addresses[0]);
+        self::assertInstanceOf(AddressDTO::class, $userDto->address);
+        self::assertInstanceOf(AddressDTO::class, $userDto->addresses[0]);
         self::assertSame('Toulon', $userDto->address->city);
         self::assertSame('Toulon', $userDto->addresses[0]->city);
         self::assertIsArray($userDto->money);
@@ -92,7 +92,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
         self::assertInstanceOf(Fixtures\UserDTO::class, $userDto);
         self::assertEquals(1, $userDto->id);
-        self::assertInstanceOf(Fixtures\AddressDTO::class, $userDto->address);
+        self::assertInstanceOf(AddressDTO::class, $userDto->address);
         self::assertSame('Toulon', $userDto->address->city);
         self::assertInstanceOf(\DateTimeInterface::class, $userDto->createdAt);
         self::assertEquals(1987, $userDto->createdAt->format('Y'));
@@ -124,7 +124,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testAutoMapperToArray(): void
     {
-        $address = new Fixtures\Address();
+        $address = new Address();
         $address->setCity('Toulon');
         $user = new Fixtures\User(1, 'yolo', '13');
         $user->address = $address;
@@ -182,7 +182,7 @@ class AutoMapperTest extends AutoMapperBaseTest
     {
         $this->buildAutoMapper(classPrefix: 'CustomDateTime_');
 
-        $address = new Fixtures\Address();
+        $address = new Address();
         $address->setCity('test');
 
         $addressArray = $this->autoMapper->map($address, 'array');
@@ -190,9 +190,9 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertIsArray($addressArray);
         self::assertArrayNotHasKey('city', $addressArray);
 
-        $addressMapped = $this->autoMapper->map($address, Fixtures\Address::class);
+        $addressMapped = $this->autoMapper->map($address, Address::class);
 
-        self::assertInstanceOf(Fixtures\Address::class, $addressMapped);
+        self::assertInstanceOf(Address::class, $addressMapped);
 
         $property = (new \ReflectionClass($addressMapped))->getProperty('city');
         $property->setAccessible(true);
@@ -777,9 +777,9 @@ class AutoMapperTest extends AutoMapperBaseTest
                 'currency' => 'EUR',
             ],
         ];
-        $order = $this->autoMapper->map($data, Fixtures\Order::class);
+        $order = $this->autoMapper->map($data, Order::class);
 
-        self::assertInstanceOf(Fixtures\Order::class, $order);
+        self::assertInstanceOf(Order::class, $order);
         self::assertInstanceOf(\Money\Money::class, $order->price);
         self::assertEquals(1000, $order->price->getAmount());
         self::assertEquals('EUR', $order->price->getCurrency()->getCode());
@@ -811,7 +811,7 @@ class AutoMapperTest extends AutoMapperBaseTest
         $newOrder = new Order();
         $newOrder = $this->autoMapper->map($order, $newOrder);
 
-        self::assertInstanceOf(Fixtures\Order::class, $newOrder);
+        self::assertInstanceOf(Order::class, $newOrder);
         self::assertInstanceOf(\Money\Money::class, $newOrder->price);
         self::assertEquals(1000, $newOrder->price->getAmount());
         self::assertEquals('EUR', $newOrder->price->getCurrency()->getCode());


### PR DESCRIPTION
This PR adds some phpdoc in generated mappers, which could be useful when debugging:

example:
```php
    /** @param array $value */   <== phpdoc added here
    public function &map($value, array $context = array()) : mixed
    {
        if (null === $value) {
            return $value;
        }
        /** @var \AutoMapper\Tests\Fixtures\AddressDTOSecondReadonlyClass $result */    <== and here
        $result = $context['target_to_populate'] ?? null;
       
        // ...
    }
```