### PR TITLE
refactor: defer transformer resolving step

### DIFF
--- a/src/Attribute/MapTo.php
+++ b/src/Attribute/MapTo.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace AutoMapper\Attribute;
 
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\MapperMetadata\MapperType;
+
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final readonly class MapTo
+final readonly class MapTo implements PropertyAttribute
 {
     /**
      * @param non-empty-string          $propertyName
@@ -15,5 +18,14 @@ final readonly class MapTo
         public string $propertyName,
         public string|null $target = null,
     ) {
+    }
+
+    public function supports(PropertyMapping $propertyMapping): bool
+    {
+        if ($propertyMapping->mapperMetadata->mapperType() === MapperType::FROM_TARGET) {
+            return false;
+        }
+
+        return null === $this->target || $propertyMapping->mapperMetadata->getTarget() === $this->target;
     }
 }

--- a/src/Attribute/PropertyAttribute.php
+++ b/src/Attribute/PropertyAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Attribute;
+
+use AutoMapper\Extractor\PropertyMapping;
+
+interface PropertyAttribute
+{
+    public function supports(PropertyMapping $propertyMapping): bool;
+}

--- a/src/CustomTransformer/AttributeCustomTransformerGenerator.php
+++ b/src/CustomTransformer/AttributeCustomTransformerGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\CustomTransformer;
+
+use AutoMapper\Attribute\PropertyAttribute;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\Extractor\ReadAccessor;
+use PhpParser\Node\Stmt;
+
+interface AttributeCustomTransformerGenerator
+{
+    public function supports(PropertyMapping $propertyMapping, PropertyAttribute $propertyAttribute): bool;
+
+    /**
+     * @return class-string<CustomTransformerInterface>
+     */
+    public function implementedClass(): string;
+
+    public function generateSupportsStatement(PropertyMapping $propertyMapping, PropertyAttribute $propertyAttribute): Stmt\ClassMethod;
+
+    public function generateTransformStatement(PropertyMapping $propertyMapping, PropertyAttribute $propertyAttribute): Stmt\ClassMethod;
+}

--- a/src/CustomTransformer/CustomTransformersRegistry.php
+++ b/src/CustomTransformer/CustomTransformersRegistry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\CustomTransformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/CustomTransformer/MapToAttributeCustomTransformerGenerator.php
+++ b/src/CustomTransformer/MapToAttributeCustomTransformerGenerator.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\CustomTransformer;
+
+use AutoMapper\Attribute\MapTo;
+use AutoMapper\Attribute\PropertyAttribute;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\Extractor\ReadAccessor;
+use AutoMapper\MapperMetadata\MapperType;
+use PhpParser\Node\Scalar\String_;
+use AutoMapper\Extractor\AstExtractor;
+use PhpParser\Builder;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\PrettyPrinter\Standard;
+
+final readonly class MapToAttributeCustomTransformerGenerator implements AttributeCustomTransformerGenerator
+{
+    public function __construct(
+        private AstExtractor $astExtractor = new AstExtractor()
+    )
+    {
+    }
+
+    public function supports(PropertyMapping $propertyMapping, PropertyAttribute $propertyAttribute): bool
+    {
+        return $propertyAttribute instanceof MapTo
+            && $propertyMapping->mapperMetadata->mapperType() === MapperType::SOURCE_TARGET;
+    }
+
+    /**
+     * @return class-string<CustomTransformerInterface>
+     */
+    public function implementedClass(): string
+    {
+        return CustomPropertyTransformerInterface::class;
+    }
+
+    /**
+     * ```php
+     * public function supports(string $source, string $target, string $propertyName): bool
+     * {
+     *     return $source === [source type] && $target === [target type] && $propertyName === [target property];
+     * }
+     * ```
+     */
+    public function generateSupportsStatement(PropertyMapping $propertyMapping, PropertyAttribute $propertyAttribute): Stmt\ClassMethod
+    {
+        $supportsMethodInInterface = $this->astExtractor
+            ->extractClassLike(CustomPropertyTransformerInterface::class)
+            ->getMethod('supports') ?? throw new \LogicException('Cannot find "supports" method in interface ' . CustomPropertyTransformerInterface::class);
+
+        return (new Builder\Method('supports'))
+            ->makePublic()
+            ->setReturnType($supportsMethodInInterface->getReturnType())
+            ->addParams($supportsMethodInInterface->getParams())
+            ->addStmt(
+                new Stmt\Return_(
+                    new Expr\BinaryOp\BooleanAnd(
+                        new Expr\BinaryOp\Identical(
+                            $supportsMethodInInterface->getParams()[0]->var,
+                            new String_($propertyMapping->mapperMetadata->getSource())
+                        ),
+                        new Expr\BinaryOp\BooleanAnd(
+                            new Expr\BinaryOp\Identical(
+                                $supportsMethodInInterface->getParams()[1]->var,
+                                new String_($propertyMapping->mapperMetadata->getTarget())
+                            ),
+                            new Expr\BinaryOp\Identical(
+                                $supportsMethodInInterface->getParams()[2]->var,
+                                new String_($propertyAttribute->propertyName)
+                            ),
+                        )
+                    )
+                )
+            )
+            ->getNode();
+    }
+
+    /**
+     * ```php
+     * public function transform(object|array $source): mixed
+     * {
+     *     return $source->[sourceProperty accessor];
+     * }
+     * ```
+     */
+    public function generateTransformStatement(PropertyMapping $propertyMapping, PropertyAttribute $propertyAttribute): Stmt\ClassMethod
+    {
+        $source = $propertyMapping->mapperMetadata->getSource();
+
+        $transformMethodInInterface = $this->astExtractor
+            ->extractClassLike(CustomTransformerInterface::class)
+            ->getMethod('transform') ?? throw new \LogicException('Cannot find "transform" method in interface ' . CustomTransformerInterface::class);
+
+        return (new Builder\Method('transform'))
+            ->makePublic()
+            ->setReturnType($transformMethodInInterface->getReturnType())
+            ->setDocComment(
+                <<<PHPDOC
+                /**
+                 * @param $source \$source
+                 */
+                PHPDOC
+            )
+            ->addParams($transformMethodInInterface->getParams())
+            ->addStmt(
+                new Stmt\Return_(
+                    $propertyMapping->readAccessor->getExpression($transformMethodInInterface->getParams()[0]->var)
+                )
+            )
+            ->getNode();
+    }
+}

--- a/src/Extractor/FromTargetMappingExtractor.php
+++ b/src/Extractor/FromTargetMappingExtractor.php
@@ -6,7 +6,7 @@ namespace AutoMapper\Extractor;
 
 use AutoMapper\CustomTransformer\CustomTransformersRegistry;
 use AutoMapper\Exception\InvalidMappingException;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use AutoMapper\Transformer\TransformerFactoryInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
@@ -56,29 +56,6 @@ final class FromTargetMappingExtractor extends MappingExtractor
                 continue;
             }
 
-            $targetTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getTarget(), $property);
-
-            if (null === $targetTypes) {
-                continue;
-            }
-
-            $sourceTypes = [];
-
-            foreach ($targetTypes as $type) {
-                $sourceType = $this->transformType($mapperMetadata->getSource(), $type);
-
-                if ($sourceType) {
-                    $sourceTypes[] = $sourceType;
-                }
-            }
-
-            $transformer = $this->customTransformerRegistry->getCustomTransformerClass($mapperMetadata, $sourceTypes, $targetTypes, $property)
-                ?? $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
-
-            if (null === $transformer) {
-                continue;
-            }
-
             $mapping[] = new PropertyMapping(
                 $mapperMetadata,
                 $this->getReadAccessor($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property),
@@ -88,7 +65,6 @@ final class FromTargetMappingExtractor extends MappingExtractor
                 $this->getWriteMutator($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property, [
                     'enable_constructor_extraction' => true,
                 ]),
-                $transformer,
                 $property,
                 true,
                 $this->getGroups($mapperMetadata->getSource(), $property),

--- a/src/Extractor/MappingExtractorInterface.php
+++ b/src/Extractor/MappingExtractorInterface.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace AutoMapper\Extractor;
 
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
+use AutoMapper\Transformer\TransformerInterface;
 
 /**
  * Extracts mapping.
@@ -31,4 +32,6 @@ interface MappingExtractorInterface
      * Extracts write mutator for a given source, target and property.
      */
     public function getWriteMutator(string $source, string $target, string $property, array $context = []): ?WriteMutator;
+
+    public function resolveTransformer(PropertyMapping $propertyMapping): TransformerInterface|string|null;
 }

--- a/src/Extractor/PropertyMapping.php
+++ b/src/Extractor/PropertyMapping.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace AutoMapper\Extractor;
 
+use AutoMapper\Attribute\PropertyAttribute;
 use AutoMapper\CustomTransformer\CustomTransformerInterface;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use AutoMapper\Transformer\TransformerInterface;
 
 /**
@@ -15,23 +16,24 @@ use AutoMapper\Transformer\TransformerInterface;
  *
  * @internal
  */
-final readonly class PropertyMapping
+final class PropertyMapping
 {
+    /** @var TransformerInterface|class-string<CustomTransformerInterface>|null */
+    private TransformerInterface|string|null $transformer = null;
+
     public function __construct(
-        public MapperGeneratorMetadataInterface $mapperMetadata,
-        public ?ReadAccessor $readAccessor,
-        public ?WriteMutator $writeMutator,
-        public ?WriteMutator $writeMutatorConstructor,
-        /** @var TransformerInterface|class-string<CustomTransformerInterface> */
-        public TransformerInterface|string $transformer,
-        public string $property,
-        public bool $checkExists = false,
-        public ?array $sourceGroups = null,
-        public ?array $targetGroups = null,
-        public ?int $maxDepth = null,
-        public bool $sourceIgnored = false,
-        public bool $targetIgnored = false,
-        public bool $isPublic = false,
+        public readonly MapperGeneratorMetadataInterface $mapperMetadata,
+        public readonly ?ReadAccessor $readAccessor,
+        public readonly ?WriteMutator $writeMutator,
+        public readonly ?WriteMutator $writeMutatorConstructor,
+        public readonly string $property,
+        public readonly bool $checkExists = false,
+        public readonly ?array $sourceGroups = null,
+        public readonly ?array $targetGroups = null,
+        public readonly ?int $maxDepth = null,
+        public readonly bool $sourceIgnored = false,
+        public readonly bool $targetIgnored = false,
+        public readonly bool $isPublic = false,
     ) {
     }
 
@@ -44,12 +46,56 @@ final readonly class PropertyMapping
     }
 
     /**
-     * @phpstan-assert-if-false TransformerInterface $this->transformer
+     * @phpstan-assert-if-false TransformerInterface $this->getTransformer()
      *
-     * @phpstan-assert-if-true string $this->transformer
+     * @phpstan-assert-if-true string $this->getTransformer()
      */
     public function hasCustomTransformer(): bool
     {
-        return \is_string($this->transformer);
+        return \is_string($this->getTransformer());
+    }
+
+    public function setTransformer(TransformerInterface|string $transformer): void
+    {
+        $this->transformer = $transformer;
+    }
+
+    public function getTransformer(): TransformerInterface|string
+    {
+        if (null === $this->transformer) {
+            throw new \LogicException('Transformer not initialized!');
+        }
+
+        return $this->transformer;
+    }
+
+    /**
+     * todo: we should also check in target attribute + check readAccessor (+ write mutators?)
+     * todo: may be in an external class?
+     */
+    public function getRelatedAttribute(): PropertyAttribute|null
+    {
+        $mapperMetadata = $this->mapperMetadata;
+
+        try {
+            $sourceReflectionClass = new \ReflectionClass($mapperMetadata->getSource());
+
+            $reflectionProperty = $sourceReflectionClass->getProperty($this->property);
+        } catch (\ReflectionException $e) {
+            return null;
+        }
+
+        $attributes = $reflectionProperty->getAttributes(PropertyAttribute::class, \ReflectionAttribute::IS_INSTANCEOF);
+        foreach ($attributes as $attribute) {
+            /** @var PropertyAttribute $attributeInstance */
+            $attributeInstance = $attribute->newInstance();
+
+            // todo: throw error if multiple attributes?
+            if ($attributeInstance->supports($this)) {
+                return $attributeInstance;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Generator/CreateTargetStatementsGenerator.php
+++ b/src/Generator/CreateTargetStatementsGenerator.php
@@ -8,8 +8,9 @@ use AutoMapper\Extractor\CustomTransformerExtractor;
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
 use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
+use AutoMapper\Generator\TransformerResolver\TransformerResolverInterface;
 use AutoMapper\MapperContext;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -214,7 +215,7 @@ final readonly class CreateTargetStatementsGenerator
              * and add it as a constructor argument
              */
             $output = $this->customTransformerExtractor->extract(
-                $propertyMapping->transformer,
+                $propertyMapping->getTransformer(),
                 $propertyMapping->readAccessor?->getExpression($variableRegistry->getSourceInput()),
                 $variableRegistry->getSourceInput()
             );
@@ -222,7 +223,7 @@ final readonly class CreateTargetStatementsGenerator
             $fieldValueExpr = $propertyMapping->readAccessor->getExpression($variableRegistry->getSourceInput());
 
             /* Get extract and transform statements for this property */
-            [$output, $propStatements] = $propertyMapping->transformer->transform($fieldValueExpr, $constructVar, $propertyMapping, $variableRegistry->getUniqueVariableScope());
+            [$output, $propStatements] = $propertyMapping->getTransformer()->transform($fieldValueExpr, $constructVar, $propertyMapping, $variableRegistry->getUniqueVariableScope());
         } else {
             return null;
         }

--- a/src/Generator/InjectMapperMethodStatementsGenerator.php
+++ b/src/Generator/InjectMapperMethodStatementsGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Generator;
 
 use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;

--- a/src/Generator/MapperConstructorGenerator.php
+++ b/src/Generator/MapperConstructorGenerator.php
@@ -6,7 +6,7 @@ namespace AutoMapper\Generator;
 
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;

--- a/src/Generator/MapperGenerator.php
+++ b/src/Generator/MapperGenerator.php
@@ -9,9 +9,12 @@ use AutoMapper\Exception\CompileException;
 use AutoMapper\Extractor\CustomTransformerExtractor;
 use AutoMapper\GeneratedMapper;
 use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
+use AutoMapper\Generator\Shared\CircularReferenceChecker;
 use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
 use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\Generator\TransformerResolver\TransformerResolverInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataRegistryInterface;
 use PhpParser\Builder;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
@@ -33,6 +36,7 @@ final readonly class MapperGenerator
     public function __construct(
         CustomTransformerExtractor $customTransformerExtractor,
         ClassDiscriminatorResolver $classDiscriminatorResolver,
+        MapperGeneratorMetadataRegistryInterface $metadataRegistry,
         bool $allowReadOnlyTargetToPopulate = false,
     ) {
         $this->mapperConstructorGenerator = new MapperConstructorGenerator(
@@ -43,6 +47,7 @@ final readonly class MapperGenerator
             $discriminatorStatementsGenerator = new DiscriminatorStatementsGenerator($classDiscriminatorResolver),
             $cachedReflectionStatementsGenerator,
             $customTransformerExtractor,
+            new CircularReferenceChecker($metadataRegistry),
             $allowReadOnlyTargetToPopulate,
         );
 
@@ -71,7 +76,8 @@ final readonly class MapperGenerator
      * Create the constructor for this mapper.
      *
      * ```php
-     * public function __construct() {
+     * public function __construct()
+     * {
      *    // construct statements
      *    $this->extractCallbacks['propertyName'] = \Closure::bind(function ($object) {
      *       return $object->propertyName;
@@ -92,7 +98,8 @@ final readonly class MapperGenerator
      * Create the map method for this mapper.
      *
      * ```php
-     * public function map($source, array $context = []) {
+     * public function map($source, array $context = [])
+     * {
      *   ... // statements
      * }
      * ```
@@ -124,7 +131,8 @@ final readonly class MapperGenerator
      * This is not done into the constructor in order to avoid circular dependency between mappers
      *
      * ```php
-     * public function injectMappers(AutoMapperRegistryInterface $autoMapperRegistry) {
+     * public function injectMappers(AutoMapperRegistryInterface $autoMapperRegistry)
+     * {
      *   // inject mapper statements
      *   $this->mappers['SOURCE_TO_TARGET_MAPPER'] = $autoMapperRegistry->getMapper($source, $target);
      *   ...

--- a/src/Generator/PropertyConditionsGenerator.php
+++ b/src/Generator/PropertyConditionsGenerator.php
@@ -163,7 +163,7 @@ final readonly class PropertyConditionsGenerator
     }
 
     /**
-     * When there is groups associated to the target property we check if the context has the same groups.
+     * When there are groups associated to the target property we check if the context has the same groups.
      *
      * ```php
      * (null !== $context[MapperContext::GROUPS] ?? null && array_intersect($context[MapperContext::GROUPS] ?? [], ['group1', 'group2']))

--- a/src/Generator/Shared/CachedReflectionStatementsGenerator.php
+++ b/src/Generator/Shared/CachedReflectionStatementsGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Generator\Shared;
 
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;

--- a/src/Generator/Shared/CircularReferenceChecker.php
+++ b/src/Generator/Shared/CircularReferenceChecker.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\Shared;
+
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataRegistryInterface;
+use AutoMapper\Transformer\DependentTransformerInterface;
+
+final readonly class CircularReferenceChecker
+{
+    public function __construct(
+        private MapperGeneratorMetadataRegistryInterface $metadataRegistry,
+    ) {
+    }
+
+    public function canHaveCircularReference(MapperGeneratorMetadataInterface $mapperMetadata): bool
+    {
+        if ('array' === $mapperMetadata->getSource()) {
+            return false;
+        }
+
+        $checked = [];
+
+        return $this->checkCircularMapperConfiguration(
+            $mapperMetadata->getSource(),
+            $mapperMetadata->getTarget(),
+            $mapperMetadata,
+            $checked
+        );
+    }
+
+    private function checkCircularMapperConfiguration(
+        string $source,
+        string $target,
+        MapperGeneratorMetadataInterface $configuration,
+        &$checked
+    ): bool {
+        foreach ($configuration->getPropertiesMapping() as $propertyMapping) {
+            $transformer = $propertyMapping->getTransformer();
+
+            if (!$transformer instanceof DependentTransformerInterface) {
+                continue;
+            }
+
+            foreach ($transformer->getDependencies() as $dependency) {
+                if (isset($checked[$dependency->name])) {
+                    continue;
+                }
+
+                $checked[$dependency->name] = true;
+
+                if ($dependency->source === $source && $dependency->target === $target) {
+                    return true;
+                }
+
+                $subConfiguration = $this->metadataRegistry->getMetadata($dependency->source, $dependency->target);
+
+                if (!$subConfiguration) {
+                    continue;
+                }
+
+                if (true === $this->checkCircularMapperConfiguration($source, $target, $subConfiguration, $checked)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Generator/Shared/ClassDiscriminatorResolver.php
+++ b/src/Generator/Shared/ClassDiscriminatorResolver.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Generator\Shared;
 
 use AutoMapper\Extractor\PropertyMapping;
-use AutoMapper\MapperGeneratorMetadataInterface;
-use AutoMapper\Transformer\TransformerInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 
@@ -24,7 +23,6 @@ final readonly class ClassDiscriminatorResolver
     {
         if (!$mapperMetadata->targetIsAUserDefinedClass()
             || !($propertyMapping = $this->propertyMapping($mapperMetadata))
-            || !$propertyMapping->transformer instanceof TransformerInterface
             || $propertyMapping->hasCustomTransformer()
         ) {
             return false;

--- a/src/Generator/Shared/DiscriminatorStatementsGenerator.php
+++ b/src/Generator/Shared/DiscriminatorStatementsGenerator.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace AutoMapper\Generator\Shared;
 
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\Generator\TransformerResolver\TransformerResolverInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use AutoMapper\Transformer\TransformerInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -20,7 +21,7 @@ use PhpParser\Node\Stmt;
 final readonly class DiscriminatorStatementsGenerator
 {
     public function __construct(
-        private ClassDiscriminatorResolver $classDiscriminatorResolver
+        private ClassDiscriminatorResolver $classDiscriminatorResolver,
     ) {
     }
 
@@ -87,7 +88,7 @@ final readonly class DiscriminatorStatementsGenerator
 
         // Generate the code that allows to put the type into the output variable,
         // so we are able to determine which mapper to use
-        [$output, $createObjectStatements] = $propertyMapping->transformer->transform(
+        [$output, $createObjectStatements] = $propertyMapping->getTransformer()->transform(
             $propertyMapping->readAccessor->getExpression($variableRegistry->getSourceInput()),
             $variableRegistry->getResult(),
             $propertyMapping,
@@ -128,6 +129,6 @@ final readonly class DiscriminatorStatementsGenerator
 
         $propertyMapping = $this->classDiscriminatorResolver->propertyMapping($mapperMetadata);
 
-        return $propertyMapping && $propertyMapping->transformer instanceof TransformerInterface;
+        return $propertyMapping && $propertyMapping->getTransformer() instanceof TransformerInterface;
     }
 }

--- a/src/Generator/TransformerResolver/ChainTransformerResolver.php
+++ b/src/Generator/TransformerResolver/ChainTransformerResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\TransformerResolver;
+
+use AutoMapper\CustomTransformer\CustomTransformersRegistry;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\Transformer\TransformerFactoryInterface;
+use AutoMapper\Transformer\TransformerInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+
+final readonly class ChainTransformerResolver implements TransformerResolverInterface
+{
+    /** @var list<TransformerResolverInterface> */
+    private array $transformerResolvers;
+
+    public function __construct(
+        TransformerResolverInterface ...$transformerResolvers
+    ) {
+        $this->transformerResolvers = $transformerResolvers;
+    }
+
+    public static function create(
+        PropertyInfoExtractorInterface $propertyInfoExtractor,
+        CustomTransformersRegistry $customTransformerRegistry,
+        TransformerFactoryInterface $transformerFactory,
+    ): self {
+        return new self(
+            ...[
+                new FromAttributeTransformerResolver($customTransformerRegistry),
+                new FromSourceTransformerResolver(
+                    $propertyInfoExtractor,
+                    $customTransformerRegistry,
+                    $transformerFactory
+                ),
+                new FromTargetTransformerResolver(
+                    $propertyInfoExtractor,
+                    $customTransformerRegistry,
+                    $transformerFactory
+                ),
+                new SourceTargetTransformerResolver(
+                    $propertyInfoExtractor,
+                    $customTransformerRegistry,
+                    $transformerFactory
+                ),
+            ]
+        );
+    }
+
+    public function resolveTransformer(PropertyMapping $propertyMapping): TransformerInterface|string|null
+    {
+        foreach ($this->transformerResolvers as $transformerResolver) {
+            if ($transformer = $transformerResolver->resolveTransformer($propertyMapping)) {
+                return $transformer;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Generator/TransformerResolver/FromAttributeTransformerResolver.php
+++ b/src/Generator/TransformerResolver/FromAttributeTransformerResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\TransformerResolver;
+
+use AutoMapper\CustomTransformer\CustomTransformerGenerator;
+use AutoMapper\CustomTransformer\CustomTransformersRegistry;
+use AutoMapper\Extractor\PropertyMapping;
+
+final readonly class FromAttributeTransformerResolver implements TransformerResolverInterface
+{
+    private CustomTransformerGenerator $customTransformerGenerator;
+
+    public function __construct(
+        CustomTransformersRegistry $customTransformerRegistry
+    ) {
+        $this->customTransformerGenerator = new CustomTransformerGenerator($customTransformerRegistry);
+    }
+
+    public function resolveTransformer(PropertyMapping $propertyMapping): string|null
+    {
+        if (null === ($propertyAttribute = $propertyMapping->getRelatedAttribute())) {
+            return null;
+        }
+
+        $transformerClass = strtr('{attributeName}_Transformer_{source}_{target}_{sourceProperty}_{targetProperty}', [
+            '{attributeName}' => (new \ReflectionClass($propertyMapping))->getShortName(),
+            '{source}' => str_replace('\\', '_', $propertyMapping->mapperMetadata->getSource()),
+            '{target}' => str_replace('\\', '_', $propertyMapping->mapperMetadata->getTarget()),
+            '{sourceProperty}' => $propertyMapping->property,
+            '{targetProperty}' => $propertyAttribute->propertyName,
+        ]);
+
+        if (!class_exists($transformerClass)) {
+            $this->customTransformerGenerator->generateMapToCustomTransformer($propertyMapping, $propertyAttribute, $transformerClass);
+        }
+
+        return $transformerClass;
+    }
+}

--- a/src/Generator/TransformerResolver/FromSourceTransformerResolver.php
+++ b/src/Generator/TransformerResolver/FromSourceTransformerResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\TransformerResolver;
+
+use AutoMapper\CustomTransformer\CustomTransformersRegistry;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\MapperMetadata\MapperType;
+use AutoMapper\Transformer\TransformerFactoryInterface;
+use AutoMapper\Transformer\TransformerInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+final readonly class FromSourceTransformerResolver implements TransformerResolverInterface
+{
+    public function __construct(
+        private PropertyInfoExtractorInterface $propertyInfoExtractor,
+        private CustomTransformersRegistry $customTransformerRegistry,
+        private TransformerFactoryInterface $transformerFactory,
+    )
+    {
+    }
+
+    public function resolveTransformer(PropertyMapping $propertyMapping): TransformerInterface|string|null
+    {
+        if ($propertyMapping->mapperMetadata->mapperType() !== MapperType::FROM_SOURCE) {
+            return null;
+        }
+
+        $mapperMetadata = $propertyMapping->mapperMetadata;
+
+        $sourceTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getSource(), $propertyMapping->property);
+
+        if (null === $sourceTypes) {
+            $sourceTypes = [new Type(Type::BUILTIN_TYPE_NULL)]; // if no types found, we force a null type
+        }
+
+        $targetTypes = [];
+
+        foreach ($sourceTypes as $type) {
+            $targetType = $this->transformType($mapperMetadata->getTarget(), $type);
+
+            if ($targetType) {
+                $targetTypes[] = $targetType;
+            }
+        }
+
+        return $this->customTransformerRegistry->getCustomTransformerClass($mapperMetadata, $sourceTypes, $targetTypes, $propertyMapping->property)
+            ?? $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+    }
+
+    private function transformType(string $target, Type $type = null): ?Type
+    {
+        if (null === $type) {
+            return null;
+        }
+
+        $builtinType = $type->getBuiltinType();
+        $className = $type->getClassName();
+
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && \stdClass::class !== $type->getClassName()) {
+            $builtinType = 'array' === $target ? Type::BUILTIN_TYPE_ARRAY : Type::BUILTIN_TYPE_OBJECT;
+            $className = 'array' === $target ? null : \stdClass::class;
+        }
+
+        // Use string for datetime
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && (\DateTimeInterface::class === $type->getClassName() || is_subclass_of($type->getClassName(), \DateTimeInterface::class))) {
+            $builtinType = 'string';
+        }
+
+        $collectionKeyTypes = $type->getCollectionKeyTypes();
+        $collectionValueTypes = $type->getCollectionValueTypes();
+
+        return new Type(
+            $builtinType,
+            $type->isNullable(),
+            $className,
+            $type->isCollection(),
+            $this->transformType($target, $collectionKeyTypes[0] ?? null),
+            $this->transformType($target, $collectionValueTypes[0] ?? null)
+        );
+    }
+}

--- a/src/Generator/TransformerResolver/FromTargetTransformerResolver.php
+++ b/src/Generator/TransformerResolver/FromTargetTransformerResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\TransformerResolver;
+
+use AutoMapper\CustomTransformer\CustomTransformersRegistry;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\MapperMetadata\MapperType;
+use AutoMapper\Transformer\TransformerFactoryInterface;
+use AutoMapper\Transformer\TransformerInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+final readonly class FromTargetTransformerResolver implements TransformerResolverInterface
+{
+    public function __construct(
+        private PropertyInfoExtractorInterface $propertyInfoExtractor,
+        private CustomTransformersRegistry $customTransformerRegistry,
+        private TransformerFactoryInterface $transformerFactory,
+    )
+    {
+    }
+
+    public function resolveTransformer(PropertyMapping $propertyMapping): TransformerInterface|string|null
+    {
+        if ($propertyMapping->mapperMetadata->mapperType() !== MapperType::FROM_TARGET) {
+            return null;
+        }
+
+        $mapperMetadata = $propertyMapping->mapperMetadata;
+
+        $targetTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getTarget(), $propertyMapping->property);
+
+        if (null === $targetTypes) {
+            return null;
+        }
+
+        $sourceTypes = [];
+
+        foreach ($targetTypes as $type) {
+            $sourceType = $this->transformType($mapperMetadata->getSource(), $type);
+
+            if ($sourceType) {
+                $sourceTypes[] = $sourceType;
+            }
+        }
+
+        return $this->customTransformerRegistry->getCustomTransformerClass($mapperMetadata, $sourceTypes, $targetTypes, $propertyMapping->property)
+            ?? $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+    }
+
+    private function transformType(string $source, ?Type $type = null): ?Type
+    {
+        if (null === $type) {
+            return null;
+        }
+
+        $builtinType = $type->getBuiltinType();
+        $className = $type->getClassName();
+
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && \stdClass::class !== $type->getClassName()) {
+            $builtinType = 'array' === $source ? Type::BUILTIN_TYPE_ARRAY : Type::BUILTIN_TYPE_OBJECT;
+            $className = 'array' === $source ? null : \stdClass::class;
+        }
+
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && (\DateTimeInterface::class === $type->getClassName() || is_subclass_of($type->getClassName(), \DateTimeInterface::class))) {
+            $builtinType = 'string';
+        }
+
+        $collectionKeyTypes = $type->getCollectionKeyTypes();
+        $collectionValueTypes = $type->getCollectionValueTypes();
+
+        return new Type(
+            $builtinType,
+            $type->isNullable(),
+            $className,
+            $type->isCollection(),
+            $this->transformType($source, $collectionKeyTypes[0] ?? null),
+            $this->transformType($source, $collectionValueTypes[0] ?? null)
+        );
+    }
+}

--- a/src/Generator/TransformerResolver/SourceTargetTransformerResolver.php
+++ b/src/Generator/TransformerResolver/SourceTargetTransformerResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\TransformerResolver;
+
+use AutoMapper\CustomTransformer\CustomTransformersRegistry;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperType;
+use AutoMapper\Transformer\TransformerFactoryInterface;
+use AutoMapper\Transformer\TransformerInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+
+final readonly class SourceTargetTransformerResolver implements TransformerResolverInterface
+{
+    public function __construct(
+        private PropertyInfoExtractorInterface $propertyInfoExtractor,
+        private CustomTransformersRegistry $customTransformerRegistry,
+        private TransformerFactoryInterface $transformerFactory,
+    )
+    {
+    }
+
+    public function resolveTransformer(PropertyMapping $propertyMapping): TransformerInterface|string|null
+    {
+        if ($propertyMapping->mapperMetadata->mapperType() !== MapperType::SOURCE_TARGET) {
+            return null;
+        }
+
+        $mapperMetadata = $propertyMapping->mapperMetadata;
+        $property = $propertyMapping->property;
+
+        $sourceTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getSource(), $property) ?? [];
+        $targetTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getTarget(), $property) ?? [];
+
+        $transformer = $this->customTransformerRegistry->getCustomTransformerClass($mapperMetadata, $sourceTypes, $targetTypes, $property);
+
+        if ($transformer || $this->shouldOUseOnlyCustomTransformer($mapperMetadata, $property)) {
+            return $transformer;
+        }
+
+        return $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+    }
+
+    // todo: this could be improved (readability)
+    private function shouldOUseOnlyCustomTransformer(MapperMetadataInterface $mapperMetadata, string $property): bool
+    {
+        $sourceProperties = $this->propertyInfoExtractor->getProperties($mapperMetadata->getSource()) ?? [];
+        $targetProperties = $this->propertyInfoExtractor->getProperties($mapperMetadata->getTarget()) ?? [];
+
+        return !\in_array($property, $sourceProperties, true)
+            && \in_array($property, $targetProperties, true);
+    }
+}

--- a/src/Generator/TransformerResolver/TransformerResolverInterface.php
+++ b/src/Generator/TransformerResolver/TransformerResolverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Generator\TransformerResolver;
+
+use AutoMapper\CustomTransformer\CustomTransformerInterface;
+use AutoMapper\Extractor\PropertyMapping;
+use AutoMapper\Transformer\TransformerInterface;
+
+interface TransformerResolverInterface
+{
+    /**
+     * @return TransformerInterface|class-string<CustomTransformerInterface>|null
+     */
+    public function resolveTransformer(PropertyMapping $propertyMapping): TransformerInterface|string|null;
+}

--- a/src/Loader/ClassLoaderInterface.php
+++ b/src/Loader/ClassLoaderInterface.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace AutoMapper\Loader;
 
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\Generator\MapperGenerator;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 
 /**
  * Loads (require) a mapping given metadata.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
  */
 interface ClassLoaderInterface
 {
-    public function loadClass(MapperGeneratorMetadataInterface $mapperMetadata): void;
+    public function loadClass(MapperGenerator $mapperGenerator, MapperGeneratorMetadataInterface $mapperMetadata): void;
 }

--- a/src/Loader/EvalLoader.php
+++ b/src/Loader/EvalLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Loader;
 
 use AutoMapper\Generator\MapperGenerator;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use PhpParser\PrettyPrinter\Standard;
 use PhpParser\PrettyPrinterAbstract;
 
@@ -13,20 +13,20 @@ use PhpParser\PrettyPrinterAbstract;
  * Use eval to load mappers.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
  */
 final readonly class EvalLoader implements ClassLoaderInterface
 {
     private PrettyPrinterAbstract $printer;
 
-    public function __construct(
-        private MapperGenerator $generator,
-    ) {
+    public function __construct() {
         $this->printer = new Standard();
     }
 
-    public function loadClass(MapperGeneratorMetadataInterface $mapperMetadata): void
+    public function loadClass(MapperGenerator $mapperGenerator, MapperGeneratorMetadataInterface $mapperMetadata): void
     {
-        $class = $this->generator->generate($mapperMetadata);
+        $class = $mapperGenerator->generate($mapperMetadata);
 
         eval($this->printer->prettyPrint([$class]));
     }

--- a/src/MapperMetadata/MapperGeneratorMetadataFactory.php
+++ b/src/MapperMetadata/MapperGeneratorMetadataFactory.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace AutoMapper;
+namespace AutoMapper\MapperMetadata;
 
 use AutoMapper\Extractor\FromSourceMappingExtractor;
 use AutoMapper\Extractor\FromTargetMappingExtractor;
 use AutoMapper\Extractor\SourceTargetMappingExtractor;
+use AutoMapper\Generator\TransformerResolver\TransformerResolverInterface;
 
 /**
  * Metadata factory, used to autoregistering new mapping without creating them.
@@ -29,7 +30,7 @@ final readonly class MapperGeneratorMetadataFactory implements MapperGeneratorMe
     /**
      * Create metadata for a source and target.
      */
-    public function create(MapperGeneratorMetadataRegistryInterface $autoMapperRegister, string $source, string $target): MapperGeneratorMetadataInterface
+    public function create(string $source, string $target): MapperGeneratorMetadataInterface
     {
         $extractor = $this->sourceTargetPropertiesMappingExtractor;
 
@@ -41,7 +42,7 @@ final readonly class MapperGeneratorMetadataFactory implements MapperGeneratorMe
             $extractor = $this->fromSourcePropertiesMappingExtractor;
         }
 
-        $mapperMetadata = new MapperMetadata($autoMapperRegister, $extractor, $source, $target, $this->isReadOnly($target), $this->mapPrivateProperties, $this->classPrefix);
+        $mapperMetadata = new MapperMetadata($extractor, $source, $target, $this->isReadOnly($target), $this->mapPrivateProperties, $this->classPrefix);
         $mapperMetadata->setAttributeChecking($this->attributeChecking);
         $mapperMetadata->setDateTimeFormat($this->dateTimeFormat);
 

--- a/src/MapperMetadata/MapperGeneratorMetadataFactoryInterface.php
+++ b/src/MapperMetadata/MapperGeneratorMetadataFactoryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AutoMapper;
+namespace AutoMapper\MapperMetadata;
 
 /**
  * Metadata factory, used to autoregistering new mapping without creating them.
@@ -11,5 +11,5 @@ namespace AutoMapper;
  */
 interface MapperGeneratorMetadataFactoryInterface
 {
-    public function create(MapperGeneratorMetadataRegistryInterface $autoMapperRegister, string $source, string $target): MapperGeneratorMetadataInterface;
+    public function create(string $source, string $target): MapperGeneratorMetadataInterface;
 }

--- a/src/MapperMetadata/MapperGeneratorMetadataInterface.php
+++ b/src/MapperMetadata/MapperGeneratorMetadataInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AutoMapper;
+namespace AutoMapper\MapperMetadata;
 
 use AutoMapper\Generator\VariableRegistry;
 
@@ -10,6 +10,8 @@ use AutoMapper\Generator\VariableRegistry;
  * Stores metadata needed when generating a mapper.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
  */
 interface MapperGeneratorMetadataInterface extends MapperMetadataInterface
 {
@@ -51,13 +53,6 @@ interface MapperGeneratorMetadataInterface extends MapperMetadataInterface
     public function isTargetCloneable(): bool;
 
     /**
-     * Whether the mapping can have circular reference.
-     *
-     * If not the case, allow to not generate code about circular references
-     */
-    public function canHaveCircularReference(): bool;
-
-    /**
      * Whether we should map private properties and methods.
      */
     public function shouldMapPrivateProperties(): bool;
@@ -72,4 +67,6 @@ interface MapperGeneratorMetadataInterface extends MapperMetadataInterface
     public function getPropertiesInConstructor(): array;
 
     public function getVariableRegistry(): VariableRegistry;
+
+    public function mapperType(): MapperType;
 }

--- a/src/MapperMetadata/MapperGeneratorMetadataRegistry.php
+++ b/src/MapperMetadata/MapperGeneratorMetadataRegistry.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\MapperMetadata;
+
+final class MapperGeneratorMetadataRegistry implements MapperGeneratorMetadataRegistryInterface
+{
+    /** @var MapperGeneratorMetadataInterface[] */
+    private array $metadata = [];
+
+    public function __construct(
+        private readonly ?MapperGeneratorMetadataFactoryInterface $mapperConfigurationFactory = null
+    )
+    {
+    }
+
+    public function register(MapperGeneratorMetadataInterface $configuration): void
+    {
+        $this->metadata[$configuration->getSource()][$configuration->getTarget()] = $configuration;
+    }
+
+    public function getMetadata(string $source, string $target): ?MapperGeneratorMetadataInterface
+    {
+        if (!isset($this->metadata[$source][$target])) {
+            if (null === $this->mapperConfigurationFactory) {
+                return null;
+            }
+
+            $this->register($this->mapperConfigurationFactory->create($source, $target));
+        }
+
+        return $this->metadata[$source][$target];
+    }
+}

--- a/src/MapperMetadata/MapperGeneratorMetadataRegistryInterface.php
+++ b/src/MapperMetadata/MapperGeneratorMetadataRegistryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AutoMapper;
+namespace AutoMapper\MapperMetadata;
 
 use AutoMapper\CustomTransformer\CustomTransformerInterface;
 use AutoMapper\Transformer\TransformerFactoryInterface;
@@ -20,16 +20,6 @@ interface MapperGeneratorMetadataRegistryInterface
      * Register metadata.
      */
     public function register(MapperGeneratorMetadataInterface $configuration): void;
-
-    /**
-     * Bind custom TransformerFactory to the AutoMapper.
-     */
-    public function bindTransformerFactory(TransformerFactoryInterface $transformerFactory): void;
-
-    /**
-     * Bind custom TransformerFactory to the AutoMapper.
-     */
-    public function bindCustomTransformer(CustomTransformerInterface $customTransformer): void;
 
     /**
      * Get metadata for a source and a target.

--- a/src/MapperMetadata/MapperMetadataInterface.php
+++ b/src/MapperMetadata/MapperMetadataInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AutoMapper;
+namespace AutoMapper\MapperMetadata;
 
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Transformer\MapperDependency;

--- a/src/MapperMetadata/MapperType.php
+++ b/src/MapperMetadata/MapperType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\MapperMetadata;
+
+enum MapperType
+{
+    case FROM_SOURCE;
+    case FROM_TARGET;
+    case SOURCE_TARGET;
+}

--- a/src/Transformer/AbstractUniqueTypeTransformerFactory.php
+++ b/src/Transformer/AbstractUniqueTypeTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/ArrayTransformerFactory.php
+++ b/src/Transformer/ArrayTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/BuiltinTransformerFactory.php
+++ b/src/Transformer/BuiltinTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/ChainTransformerFactory.php
+++ b/src/Transformer/ChainTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>

--- a/src/Transformer/DateTimeTransformerFactory.php
+++ b/src/Transformer/DateTimeTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/EnumTransformerFactory.php
+++ b/src/Transformer/EnumTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/MultipleTransformerFactory.php
+++ b/src/Transformer/MultipleTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>

--- a/src/Transformer/NullableTransformerFactory.php
+++ b/src/Transformer/NullableTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/ObjectTransformerFactory.php
+++ b/src/Transformer/ObjectTransformerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Transformer;
 
 use AutoMapper\AutoMapperRegistryInterface;
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/SymfonyUidTransformerFactory.php
+++ b/src/Transformer/SymfonyUidTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Uid\Ulid;

--- a/src/Transformer/TransformerFactoryInterface.php
+++ b/src/Transformer/TransformerFactoryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**

--- a/src/Transformer/UniqueTypeTransformerFactory.php
+++ b/src/Transformer/UniqueTypeTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 
 /**
  * Reduce array of type to only one type on source and target.

--- a/tests/Attributes/MapToTest.php
+++ b/tests/Attributes/MapToTest.php
@@ -10,7 +10,7 @@ use AutoMapper\Tests\Fixtures\User;
 
 class MapToTest extends AutoMapperBaseTest
 {
-    public function testMapTo(): void
+    public function testMapToObject(): void
     {
         $user = $this->autoMapper->map(new UserDTOWithMapTo(), User::class);
 

--- a/tests/AutoMapperBaseTest.php
+++ b/tests/AutoMapperBaseTest.php
@@ -5,16 +5,10 @@ declare(strict_types=1);
 namespace AutoMapper\Tests;
 
 use AutoMapper\AutoMapper;
-use AutoMapper\Extractor\ClassMethodToCallbackExtractor;
-use AutoMapper\Extractor\CustomTransformerExtractor;
-use AutoMapper\Generator\MapperGenerator;
-use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
 use AutoMapper\Loader\ClassLoaderInterface;
 use AutoMapper\Loader\FileLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
-use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 
 /**
@@ -31,18 +25,21 @@ abstract class AutoMapperBaseTest extends TestCase
         $this->buildAutoMapper();
     }
 
-    protected function buildAutoMapper(bool $allowReadOnlyTargetToPopulate = false, bool $mapPrivatePropertiesAndMethod = false, string $classPrefix = 'Mapper_'): AutoMapper
-    {
+    protected function buildAutoMapper(
+        bool $allowReadOnlyTargetToPopulate = false,
+        bool $mapPrivatePropertiesAndMethod = false,
+        string $classPrefix = 'Mapper_'
+    ): AutoMapper {
         $fs = new Filesystem();
         $fs->remove(__DIR__ . '/cache/');
-        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
 
-        $this->loader = new FileLoader(new MapperGenerator(
-            new CustomTransformerExtractor(new ClassMethodToCallbackExtractor()),
-            new ClassDiscriminatorResolver(new ClassDiscriminatorFromClassMetadata($classMetadataFactory)),
-            $allowReadOnlyTargetToPopulate
-        ), __DIR__ . '/cache');
+        $this->loader = new FileLoader(__DIR__ . '/cache');
 
-        return $this->autoMapper = AutoMapper::create($mapPrivatePropertiesAndMethod, $this->loader, classPrefix: $classPrefix);
+        return $this->autoMapper = AutoMapper::create(
+            $mapPrivatePropertiesAndMethod,
+            $this->loader,
+            classPrefix: $classPrefix,
+            allowReadOnlyTargetToPopulate: $allowReadOnlyTargetToPopulate
+        );
     }
 }

--- a/tests/Extractor/FromSourceMappingExtractorTest.php
+++ b/tests/Extractor/FromSourceMappingExtractorTest.php
@@ -8,7 +8,7 @@ use AutoMapper\CustomTransformer\CustomTransformersRegistry;
 use AutoMapper\Exception\InvalidMappingException;
 use AutoMapper\Extractor\FromSourceMappingExtractor;
 use AutoMapper\Extractor\PropertyMapping;
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Tests\AutoMapperBaseTest;
 use AutoMapper\Tests\Fixtures;
 use AutoMapper\Transformer\ArrayTransformerFactory;
@@ -79,7 +79,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
     public function testWithTargetAsArray(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: Fixtures\User::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: Fixtures\User::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $sourcePropertiesMapping);
@@ -92,7 +92,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
     public function testWithTargetAsStdClass(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: Fixtures\User::class, target: 'stdClass', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: Fixtures\User::class, target: 'stdClass', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $sourcePropertiesMapping);
@@ -104,7 +104,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
 
     public function testWithSourceAsEmpty(): void
     {
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: Fixtures\Empty_::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: Fixtures\Empty_::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(0, $sourcePropertiesMapping);
@@ -113,12 +113,12 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
     public function testWithSourceAsPrivate(): void
     {
         $privateReflection = new \ReflectionClass(Fixtures\Private_::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: Fixtures\Private_::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: Fixtures\Private_::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(\count($privateReflection->getProperties()), $sourcePropertiesMapping);
 
         $this->fromSourceMappingExtractorBootstrap(false);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: Fixtures\Private_::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: Fixtures\Private_::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(0, $sourcePropertiesMapping);
     }
@@ -128,7 +128,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a target');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: 'array', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: 'array', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 
@@ -137,7 +137,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a target');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, source: 'stdClass', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromSourceMappingExtractor, source: 'stdClass', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 }

--- a/tests/Extractor/FromTargetMappingExtractorTest.php
+++ b/tests/Extractor/FromTargetMappingExtractorTest.php
@@ -7,7 +7,7 @@ namespace AutoMapper\Tests\Extractor;
 use AutoMapper\CustomTransformer\CustomTransformersRegistry;
 use AutoMapper\Exception\InvalidMappingException;
 use AutoMapper\Extractor\FromTargetMappingExtractor;
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Tests\AutoMapperBaseTest;
 use AutoMapper\Tests\Fixtures;
 use AutoMapper\Transformer\ArrayTransformerFactory;
@@ -79,7 +79,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
     public function testWithSourceAsArray(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: 'array', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: 'array', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $targetPropertiesMapping);
@@ -91,7 +91,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
     public function testWithSourceAsStdClass(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: 'stdClass', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: 'stdClass', target: Fixtures\User::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $targetPropertiesMapping);
@@ -102,7 +102,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
 
     public function testWithTargetAsEmpty(): void
     {
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: 'array', target: Fixtures\Empty_::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: 'array', target: Fixtures\Empty_::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(0, $targetPropertiesMapping);
@@ -111,12 +111,12 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
     public function testWithTargetAsPrivate(): void
     {
         $privateReflection = new \ReflectionClass(Fixtures\Private_::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: 'array', target: Fixtures\Private_::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: 'array', target: Fixtures\Private_::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(\count($privateReflection->getProperties()), $targetPropertiesMapping);
 
         $this->fromTargetMappingExtractorBootstrap(false);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: 'array', target: Fixtures\Private_::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: 'array', target: Fixtures\Private_::class, isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(0, $targetPropertiesMapping);
     }
@@ -126,7 +126,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a source');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: Fixtures\User::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: Fixtures\User::class, target: 'array', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 
@@ -135,7 +135,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a source');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, source: Fixtures\User::class, target: 'stdClass', isTargetReadOnlyClass: false, mapPrivateProperties: true);
+        $mapperMetadata = new MapperMetadata($this->fromTargetMappingExtractor, source: Fixtures\User::class, target: 'stdClass', isTargetReadOnlyClass: false, mapPrivateProperties: true);
         $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 }

--- a/tests/Fixtures/Transformer/MoneyTransformerFactory.php
+++ b/tests/Fixtures/Transformer/MoneyTransformerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Fixtures\Transformer;
 
-use AutoMapper\MapperMetadataInterface;
+use AutoMapper\MapperMetadata\MapperMetadataInterface;
 use AutoMapper\Transformer\AbstractUniqueTypeTransformerFactory;
 use AutoMapper\Transformer\TransformerInterface;
 use Money\Money;

--- a/tests/MapperGeneratorMetadataFactoryTest.php
+++ b/tests/MapperGeneratorMetadataFactoryTest.php
@@ -9,8 +9,8 @@ use AutoMapper\Extractor\FromSourceMappingExtractor;
 use AutoMapper\Extractor\FromTargetMappingExtractor;
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Extractor\SourceTargetMappingExtractor;
-use AutoMapper\MapperGeneratorMetadataFactory;
-use AutoMapper\MapperGeneratorMetadataFactoryInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataFactory;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataFactoryInterface;
 use AutoMapper\Transformer\ArrayTransformerFactory;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;
@@ -95,7 +95,7 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
 
-        $metadata = $this->factory->create($this->autoMapper, Fixtures\User::class, 'array');
+        $metadata = $this->factory->create(Fixtures\User::class, 'array');
         self::assertFalse($metadata->hasConstructor());
         self::assertTrue($metadata->shouldCheckAttributes());
         self::assertFalse($metadata->isTargetCloneable());
@@ -111,7 +111,7 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
 
-        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\User::class);
+        $metadata = $this->factory->create('array', Fixtures\User::class);
         self::assertTrue($metadata->hasConstructor());
         self::assertTrue($metadata->shouldCheckAttributes());
         self::assertTrue($metadata->isTargetCloneable());
@@ -125,7 +125,7 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
 
     public function testCreateWithBothObjects(): void
     {
-        $metadata = $this->factory->create($this->autoMapper, Fixtures\UserConstructorDTO::class, Fixtures\User::class);
+        $metadata = $this->factory->create(Fixtures\UserConstructorDTO::class, Fixtures\User::class);
         self::assertTrue($metadata->hasConstructor());
         self::assertTrue($metadata->shouldCheckAttributes());
         self::assertTrue($metadata->isTargetCloneable());
@@ -139,7 +139,7 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
 
     public function testHasNotConstructor(): void
     {
-        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\UserDTO::class);
+        $metadata = $this->factory->create('array', Fixtures\UserDTO::class);
 
         self::assertFalse($metadata->hasConstructor());
     }
@@ -149,7 +149,7 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
      */
     public function testTargetIsReadOnlyClass(): void
     {
-        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\AddressDTOReadonlyClass::class);
+        $metadata = $this->factory->create('array', Fixtures\AddressDTOReadonlyClass::class);
 
         self::assertEquals(Fixtures\AddressDTOReadonlyClass::class, $metadata->getTarget());
         self::assertTrue($metadata->isTargetReadOnlyClass());

--- a/tests/Transformer/ArrayTransformerFactoryTest.php
+++ b/tests/Transformer/ArrayTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\ArrayTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;
 use AutoMapper\Transformer\CopyTransformer;

--- a/tests/Transformer/BuiltinTransformerFactoryTest.php
+++ b/tests/Transformer/BuiltinTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\BuiltinTransformer;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use PHPUnit\Framework\TestCase;

--- a/tests/Transformer/ChainTransformerFactoryTest.php
+++ b/tests/Transformer/ChainTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\ChainTransformerFactory;
 use AutoMapper\Transformer\CopyTransformer;
 use AutoMapper\Transformer\TransformerFactoryInterface;

--- a/tests/Transformer/DateTimeTransformerFactoryTest.php
+++ b/tests/Transformer/DateTimeTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\DateTimeInterfaceToImmutableTransformer;
 use AutoMapper\Transformer\DateTimeInterfaceToMutableTransformer;
 use AutoMapper\Transformer\DateTimeToStringTransformer;

--- a/tests/Transformer/EvalTransformerTrait.php
+++ b/tests/Transformer/EvalTransformerTrait.php
@@ -7,7 +7,7 @@ namespace AutoMapper\Tests\Transformer;
 use AutoMapper\Extractor\PropertyMapping;
 use AutoMapper\Extractor\ReadAccessor;
 use AutoMapper\Generator\UniqueVariableScope;
-use AutoMapper\MapperGeneratorMetadataInterface;
+use AutoMapper\MapperMetadata\MapperGeneratorMetadataInterface;
 use AutoMapper\Transformer\TransformerInterface;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
@@ -24,9 +24,9 @@ trait EvalTransformerTrait
                 new ReadAccessor(ReadAccessor::TYPE_PROPERTY, 'dummy'),
                 null,
                 null,
-                $transformer,
                 'dummy'
             );
+            $propertyMapping->setTransformer($transformer);
         }
 
         $variableScope = new UniqueVariableScope();

--- a/tests/Transformer/MultipleTransformerFactoryTest.php
+++ b/tests/Transformer/MultipleTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\BuiltinTransformer;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;

--- a/tests/Transformer/NullableTransformerFactoryTest.php
+++ b/tests/Transformer/NullableTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;
 use AutoMapper\Transformer\NullableTransformer;

--- a/tests/Transformer/ObjectTransformerFactoryTest.php
+++ b/tests/Transformer/ObjectTransformerFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Tests\Transformer;
 
 use AutoMapper\AutoMapperRegistryInterface;
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\ObjectTransformer;
 use AutoMapper\Transformer\ObjectTransformerFactory;
 use PHPUnit\Framework\TestCase;

--- a/tests/Transformer/SymfonyUidTransformerFactoryTest.php
+++ b/tests/Transformer/SymfonyUidTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\SymfonyUidCopyTransformer;
 use AutoMapper\Transformer\SymfonyUidTransformerFactory;
 use PHPUnit\Framework\TestCase;

--- a/tests/Transformer/UniqueTypeTransformerFactoryTest.php
+++ b/tests/Transformer/UniqueTypeTransformerFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Transformer;
 
-use AutoMapper\MapperMetadata;
+use AutoMapper\MapperMetadata\MapperMetadata;
 use AutoMapper\Transformer\BuiltinTransformer;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;


### PR DESCRIPTION
Here is some more code on the road to use attributes to configure the automapper.

it is still a "Work In Progress" stuff: I focus on keeping phpunit green. I don't want to fight with PHPStan for now, since a lot of things will be refactored (and we're targetting a temporary branch).

About the work in this PR: I feel like we should use `PropertyMapping` objects to resolve the related attributes (see `PropertyMapping::getRelatedAttribute()`), so I needed to remove the `$transformer` from the `PropertyMapping` and resolve it later