### PR TITLE
feat(generator): allow skipping uninitialized property when skipping null values

### DIFF
--- a/src/GeneratedMapper.php
+++ b/src/GeneratedMapper.php
@@ -19,6 +19,9 @@ abstract class GeneratedMapper implements MapperInterface
 
     protected $extractCallbacks = [];
 
+    /** @var callable[] */
+    protected array $extractIsNullCallbacks = [];
+
     protected $cachedTarget;
 
     protected $circularReferenceHandler;

--- a/src/Generator/MapperConstructorGenerator.php
+++ b/src/Generator/MapperConstructorGenerator.php
@@ -30,6 +30,7 @@ final readonly class MapperConstructorGenerator
 
         foreach ($mapperMetadata->getPropertiesMapping() as $propertyMapping) {
             $constructStatements[] = $this->extractCallbackForProperty($propertyMapping);
+            $constructStatements[] = $this->extractIsNullCallbackForProperty($propertyMapping);
             $constructStatements[] = $this->hydrateCallbackForProperty($propertyMapping);
         }
 
@@ -59,6 +60,30 @@ final readonly class MapperConstructorGenerator
             new Expr\Assign(
                 new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'extractCallbacks'), new Scalar\String_($propertyMapping->property)),
                 $extractCallback
+            ));
+    }
+
+    /**
+     * Add read callback to the constructor of the generated mapper.
+     *
+     * ```php
+     * $this->extractIsNullCallbacks['propertyName'] = $extractIsNullCallback;
+     * ```
+     */
+    private function extractIsNullCallbackForProperty(PropertyMapping $propertyMapping): ?Stmt\Expression
+    {
+        $mapperMetadata = $propertyMapping->mapperMetadata;
+
+        $extractNullCallback = $propertyMapping->readAccessor?->getExtractIsNullCallback($mapperMetadata->getSource());
+
+        if (!$extractNullCallback) {
+            return null;
+        }
+
+        return new Stmt\Expression(
+            new Expr\Assign(
+                new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'extractIsNullCallbacks'), new Scalar\String_($propertyMapping->property)),
+                $extractNullCallback
             ));
     }
 

--- a/src/Generator/PropertyConditionsGenerator.php
+++ b/src/Generator/PropertyConditionsGenerator.php
@@ -112,16 +112,10 @@ final readonly class PropertyConditionsGenerator
 
         $variableRegistry = $mapperMetadata->getVariableRegistry();
 
-        /** Create expression on how to read the value from the source */
-        $sourcePropertyAccessor = new Expr\Assign(
-            $variableRegistry->getFieldValueVariable($propertyMapping),
-            $propertyMapping->readAccessor->getExpression($variableRegistry->getSourceInput())
-        );
-
         return new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'isAllowedAttribute', [
             new Arg($variableRegistry->getContext()),
             new Arg(new Scalar\String_($propertyMapping->property)),
-            new Arg($sourcePropertyAccessor),
+            new Arg($propertyMapping->readAccessor->getIsNullExpression($variableRegistry->getSourceInput())),
         ]);
     }
 

--- a/src/Generator/PropertyConditionsGenerator.php
+++ b/src/Generator/PropertyConditionsGenerator.php
@@ -99,7 +99,7 @@ final readonly class PropertyConditionsGenerator
      * In case of supporting attributes checking, we check if the property is allowed to be mapped.
      *
      * ```php
-     * MapperContext::isAllowedAttribute($context, 'propertyName', $source).
+     * MapperContext::isAllowedAttribute($context, 'propertyName', isset($source->field)).
      * ```
      */
     private function isAllowedAttribute(PropertyMapping $propertyMapping): ?Expr

--- a/src/Generator/PropertyStatementsGenerator.php
+++ b/src/Generator/PropertyStatementsGenerator.php
@@ -35,12 +35,16 @@ final readonly class PropertyStatementsGenerator
         }
 
         $variableRegistry = $mapperMetadata->getVariableRegistry();
-
         $fieldValueVariable = $variableRegistry->getFieldValueVariable($propertyMapping);
 
+        if ($propertyMapping->readAccessor) {
+            $fieldValueVariable = $propertyMapping->readAccessor->getExpression($variableRegistry->getSourceInput());
+        }
+
         if ($propertyMapping->hasCustomTransformer()) {
-            $output = $this->customTransformerExtractor->extract($propertyMapping->transformer, $fieldValueVariable, $variableRegistry->getSourceInput());
             $propStatements = [];
+
+            $output = $this->customTransformerExtractor->extract($propertyMapping->transformer, $fieldValueVariable, $variableRegistry->getSourceInput());
         } else {
             /* Create expression to transform the read value into the wanted written value, depending on the transform it may add new statements to get the correct value */
             [$output, $propStatements] = $propertyMapping->transformer->transform(

--- a/src/MapperContext.php
+++ b/src/MapperContext.php
@@ -174,6 +174,8 @@ class MapperContext
 
     /**
      * Check whether an attribute is allowed to be mapped.
+     *
+     * @internal
      */
     public static function isAllowedAttribute(array $context, string $attribute, bool $valueIsNotNullOrNotUndefined): bool
     {

--- a/src/MapperContext.php
+++ b/src/MapperContext.php
@@ -175,9 +175,9 @@ class MapperContext
     /**
      * Check whether an attribute is allowed to be mapped.
      */
-    public static function isAllowedAttribute(array $context, string $attribute, $value): bool
+    public static function isAllowedAttribute(array $context, string $attribute, bool $valueIsNotNullOrNotUndefined): bool
     {
-        if (($context[self::SKIP_NULL_VALUES] ?? false) && null === $value) {
+        if (($context[self::SKIP_NULL_VALUES] ?? false) && !$valueIsNotNullOrNotUndefined) {
             return false;
         }
 

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -31,6 +31,7 @@ use AutoMapper\Tests\Fixtures\ObjectWithDateTime;
 use AutoMapper\Tests\Fixtures\Order;
 use AutoMapper\Tests\Fixtures\PetOwner;
 use AutoMapper\Tests\Fixtures\Transformer\MoneyTransformerFactory;
+use AutoMapper\Tests\Fixtures\Uninitialized;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Uid\Ulid;
@@ -1264,6 +1265,16 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertEquals(
             new ClassWithNullablePropertyInConstructor(foo: 1),
             $this->autoMapper->map(['foo' => 1], ClassWithNullablePropertyInConstructor::class)
+        );
+    }
+
+    public function testNoErrorWithUninitializedProperty(): void
+    {
+        $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true);
+
+        self::assertSame(
+            ['bar' => 'bar'],
+            $this->autoMapper->map(new Uninitialized(), 'array', ['skip_null_values' => true])
         );
     }
 }

--- a/tests/Fixtures/Uninitialized.php
+++ b/tests/Fixtures/Uninitialized.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+class Uninitialized
+{
+    public string $foo;
+
+    public string $bar = 'bar';
+}

--- a/tests/MapperContextTest.php
+++ b/tests/MapperContextTest.php
@@ -19,9 +19,9 @@ class MapperContextTest extends TestCase
         $context->setAllowedAttributes(['id', 'age']);
         $context->setIgnoredAttributes(['age']);
 
-        self::assertTrue(MapperContext::isAllowedAttribute($context->toArray(), 'id', 1));
-        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'age', 29));
-        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'name', 'Baptiste'));
+        self::assertTrue(MapperContext::isAllowedAttribute($context->toArray(), 'id', true));
+        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'age', true));
+        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'name', true));
     }
 
     public function testCircularReferenceLimit(): void
@@ -127,7 +127,7 @@ class MapperContextTest extends TestCase
             ],
         ];
 
-        self::assertTrue(MapperContext::isAllowedAttribute($context, 'foo', 1));
+        self::assertTrue(MapperContext::isAllowedAttribute($context, 'foo', true));
         $newContext = MapperContext::withNewContext($context, 'foo');
 
         self::assertEquals(['bar'], $newContext[MapperContext::ALLOWED_ATTRIBUTES]);
@@ -136,6 +136,6 @@ class MapperContextTest extends TestCase
     public function testSkipNullValues(): void
     {
         $context = [MapperContext::SKIP_NULL_VALUES => true];
-        self::assertFalse(MapperContext::isAllowedAttribute($context, 'id', null));
+        self::assertFalse(MapperContext::isAllowedAttribute($context, 'id', false));
     }
 }

--- a/tools/phpstan/phpstan-baseline.neon
+++ b/tools/phpstan/phpstan-baseline.neon
@@ -346,11 +346,6 @@ parameters:
 			path: ../../src/MapperContext.php
 
 		-
-			message: "#^Method AutoMapper\\\\MapperContext\\:\\:isAllowedAttribute\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: ../../src/MapperContext.php
-
-		-
 			message: "#^Method AutoMapper\\\\MapperContext\\:\\:setAllowedAttributes\\(\\) has parameter \\$allowedAttributes with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../src/MapperContext.php


### PR DESCRIPTION
Fixes #43 

Instead of getting the value we do a check on whether the value is null or undefined, this allow skipping mapping uninitialized property also.

Without this change it php would throw an error as we try to get a uninitialized property value