### PR TITLE
chore(test): remove most of deprecations in test

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -167,6 +167,9 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
         $this->customTransformersRegistry->addCustomTransformer($customTransformer, $id);
     }
 
+    /**
+     * @param list<TransformerFactoryInterface> $transformerFactories
+     */
     public static function create(
         bool $mapPrivateProperties = false,
         ClassLoaderInterface $loader = null,
@@ -176,6 +179,7 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
         bool $autoRegister = true,
         string $dateTimeFormat = \DateTimeInterface::RFC3339,
         bool $allowReadOnlyTargetToPopulate = false,
+        array $transformerFactories = [],
     ): self {
         if (class_exists(AttributeLoader::class)) {
             $loaderClass = new AttributeLoader();
@@ -222,6 +226,10 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
 
         if (class_exists(AbstractUid::class)) {
             $factories[] = new SymfonyUidTransformerFactory();
+        }
+
+        foreach ($transformerFactories as $factory) {
+            $factories[] = $factory;
         }
 
         $transformerFactory = new ChainTransformerFactory($factories);

--- a/tests/AutoMapperBaseTest.php
+++ b/tests/AutoMapperBaseTest.php
@@ -31,7 +31,7 @@ abstract class AutoMapperBaseTest extends TestCase
         $this->buildAutoMapper();
     }
 
-    protected function buildAutoMapper(bool $allowReadOnlyTargetToPopulate = false, bool $mapPrivatePropertiesAndMethod = false, string $classPrefix = 'Mapper_'): AutoMapper
+    protected function buildAutoMapper(bool $allowReadOnlyTargetToPopulate = false, bool $mapPrivatePropertiesAndMethod = false, string $classPrefix = 'Mapper_', array $transformerFactories = []): AutoMapper
     {
         $fs = new Filesystem();
         $fs->remove(__DIR__ . '/cache/');
@@ -48,6 +48,6 @@ abstract class AutoMapperBaseTest extends TestCase
             $allowReadOnlyTargetToPopulate
         ), __DIR__ . '/cache');
 
-        return $this->autoMapper = AutoMapper::create($mapPrivatePropertiesAndMethod, $this->loader, classPrefix: $classPrefix);
+        return $this->autoMapper = AutoMapper::create($mapPrivatePropertiesAndMethod, $this->loader, classPrefix: $classPrefix, transformerFactories: $transformerFactories);
     }
 }

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -769,9 +769,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testCustomTransformerFromArrayToObject(): void
     {
-        $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true);
-
-        $this->autoMapper->bindTransformerFactory(new MoneyTransformerFactory());
+        $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true, transformerFactories: [new MoneyTransformerFactory()]);
 
         $data = [
             'id' => 4582,
@@ -790,7 +788,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testCustomTransformerFromObjectToArray(): void
     {
-        $this->autoMapper->bindTransformerFactory(new MoneyTransformerFactory());
+        $this->buildAutoMapper(transformerFactories: [new MoneyTransformerFactory()]);
 
         $order = new Order();
         $order->id = 4582;
@@ -806,7 +804,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testCustomTransformerFromObjectToObject(): void
     {
-        $this->autoMapper->bindTransformerFactory(new MoneyTransformerFactory());
+        $this->buildAutoMapper(transformerFactories: [new MoneyTransformerFactory()]);
 
         $order = new Order();
         $order->id = 4582;

--- a/tests/Transformer/ChainTransformerFactoryTest.php
+++ b/tests/Transformer/ChainTransformerFactoryTest.php
@@ -14,7 +14,6 @@ class ChainTransformerFactoryTest extends TestCase
 {
     public function testGetTransformer(): void
     {
-        $chainTransformerFactory = new ChainTransformerFactory();
         $transformer = new CopyTransformer();
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
         $subTransformer = $this
@@ -23,7 +22,8 @@ class ChainTransformerFactoryTest extends TestCase
         ;
 
         $subTransformer->expects($this->any())->method('getTransformer')->willReturn($transformer);
-        $chainTransformerFactory->addTransformerFactory($subTransformer);
+
+        $chainTransformerFactory = new ChainTransformerFactory([$subTransformer]);
 
         $transformerReturned = $chainTransformerFactory->getTransformer([], [], $mapperMetadata);
 
@@ -32,7 +32,6 @@ class ChainTransformerFactoryTest extends TestCase
 
     public function testNoTransformer(): void
     {
-        $chainTransformerFactory = new ChainTransformerFactory();
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
         $subTransformer = $this
             ->getMockBuilder(TransformerFactoryInterface::class)
@@ -40,7 +39,7 @@ class ChainTransformerFactoryTest extends TestCase
         ;
 
         $subTransformer->expects($this->any())->method('getTransformer')->willReturn(null);
-        $chainTransformerFactory->addTransformerFactory($subTransformer);
+        $chainTransformerFactory = new ChainTransformerFactory([$subTransformer]);
 
         $transformerReturned = $chainTransformerFactory->getTransformer([], [], $mapperMetadata);
 

--- a/tests/Transformer/EvalTransformerTrait.php
+++ b/tests/Transformer/EvalTransformerTrait.php
@@ -32,9 +32,10 @@ trait EvalTransformerTrait
         $variableScope = new UniqueVariableScope();
         $inputName = $variableScope->getUniqueName('input');
         $inputExpr = new Expr\Variable($inputName);
+        $sourceExpr = new Expr\Variable('source');
 
         // we give $inputExpr as $targetExpr since we don't use it there and this is needed by TransformerInterface
-        [$outputExpr, $stmts] = $transformer->transform($inputExpr, $inputExpr, $propertyMapping, $variableScope);
+        [$outputExpr, $stmts] = $transformer->transform($inputExpr, $inputExpr, $propertyMapping, $variableScope, $sourceExpr);
 
         $stmts[] = new Stmt\Return_($outputExpr);
 

--- a/tests/Transformer/MultipleTransformerFactoryTest.php
+++ b/tests/Transformer/MultipleTransformerFactoryTest.php
@@ -17,12 +17,9 @@ class MultipleTransformerFactoryTest extends TestCase
 {
     public function testGetTransformer(): void
     {
-        $chainFactory = new ChainTransformerFactory();
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
         $factory = new MultipleTransformerFactory();
         $factory->setChainTransformerFactory($chainFactory);
-
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
 
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 
@@ -52,12 +49,9 @@ class MultipleTransformerFactoryTest extends TestCase
 
     public function testNoTransformer(): void
     {
-        $chainFactory = new ChainTransformerFactory();
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
         $factory = new MultipleTransformerFactory();
         $factory->setChainTransformerFactory($chainFactory);
-
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
 
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 

--- a/tests/Transformer/NullableTransformerFactoryTest.php
+++ b/tests/Transformer/NullableTransformerFactoryTest.php
@@ -24,11 +24,10 @@ class NullableTransformerFactoryTest extends TestCase
 
     public function testGetTransformer(): void
     {
-        $chainFactory = new ChainTransformerFactory();
-        $factory = new NullableTransformerFactory($chainFactory);
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
+        $factory = new NullableTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
 
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 
         $transformer = $factory->getTransformer([new Type('string', true)], [new Type('string')], $mapperMetadata);
@@ -58,11 +57,10 @@ class NullableTransformerFactoryTest extends TestCase
 
     public function testNullTransformerIfSourceTypeNotNullable(): void
     {
-        $chainFactory = new ChainTransformerFactory();
-        $factory = new NullableTransformerFactory($chainFactory);
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
+        $factory = new NullableTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
 
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 
         $transformer = $factory->getTransformer([new Type('string')], [new Type('string')], $mapperMetadata);
@@ -72,11 +70,10 @@ class NullableTransformerFactoryTest extends TestCase
 
     public function testNullTransformerIfMultipleSource(): void
     {
-        $chainFactory = new ChainTransformerFactory();
-        $factory = new NullableTransformerFactory($chainFactory);
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
+        $factory = new NullableTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
 
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 
         $transformer = $factory->getTransformer([new Type('string', true), new Type('string')], [new Type('string')], $mapperMetadata);

--- a/tests/Transformer/UniqueTypeTransformerFactoryTest.php
+++ b/tests/Transformer/UniqueTypeTransformerFactoryTest.php
@@ -16,11 +16,9 @@ class UniqueTypeTransformerFactoryTest extends TestCase
 {
     public function testGetTransformer(): void
     {
-        $chainFactory = new ChainTransformerFactory();
-        $factory = new UniqueTypeTransformerFactory($chainFactory);
-
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
+        $factory = new UniqueTypeTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
 
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 
@@ -32,11 +30,9 @@ class UniqueTypeTransformerFactoryTest extends TestCase
 
     public function testNullTransformer(): void
     {
-        $chainFactory = new ChainTransformerFactory();
-        $factory = new UniqueTypeTransformerFactory($chainFactory);
-
-        $chainFactory->addTransformerFactory($factory);
-        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $chainFactory = new ChainTransformerFactory([new BuiltinTransformerFactory()]);
+        $factory = new UniqueTypeTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
 
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 


### PR DESCRIPTION
There is still the `forMember` deprecation, but we should remove it in 9.0 since there is no direct replacement for it