### PR TITLE
feat(attribute): add map to attribute

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,24 @@ class InputUser
 }
 ```
 
+#### Using the `#[MapFrom]` attribute
+
+You can use the `#[MapFrom]` attribute to specify the source name of a property. It works the same way as the `#[MapTo]`
+attribute but for the source class. This is useful when the source is an array or a `stdClass` object.
+
+```php
+class InputUser
+{
+  public function __construct(
+    public readonly string $firstName,
+    public readonly string $lastName,
+    #[MapFrom(name: 'userAge', source: 'array')]
+    public readonly int $age,
+  ) {
+  }
+}
+```
+
 #### Using a custom transformer
 
 You can use a custom transformer to transform the value of a property. This is useful when you need to transform the

--- a/src/Attribute/MapFrom.php
+++ b/src/Attribute/MapFrom.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Attribute;
+
+/**
+ * Configures a property to map to.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final readonly class MapFrom
+{
+    /**
+     * @param class-string|'array'|null                                 $source      The specific source class name or array. If null this attribute will be used for all source classes.
+     * @param string|null                                               $name        The source property name. If null, the target property name will be used.
+     * @param int|null                                                  $maxDepth    The maximum depth of the mapping. If null, the default max depth will be used.
+     * @param string|callable(mixed $value, object $object): mixed|null $transformer A transformer id or a callable that transform the value during mapping
+     * @param bool|null                                                 $ignore      if true, the property will be ignored during mapping
+     */
+    public function __construct(
+        public ?string $source = null,
+        public ?string $name = null,
+        public ?int $maxDepth = null,
+        public mixed $transformer = null,
+        public ?bool $ignore = null,
+    ) {
+    }
+}

--- a/src/Attribute/MapTo.php
+++ b/src/Attribute/MapTo.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Attribute;
+
+/**
+ * Configures a property to map to.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final readonly class MapTo
+{
+    /**
+     * @param class-string|'array'|null                                 $target      The specific target class name or array. If null this attribute will be used for all target classes.
+     * @param string|null                                               $name        The target property name. If null, the source property name will be used.
+     * @param int|null                                                  $maxDepth    The maximum depth of the mapping. If null, the default max depth will be used.
+     * @param string|callable(mixed $value, object $object): mixed|null $transformer A transformer id or a callable that transform the value during mapping
+     * @param bool|null                                                 $ignore      if true, the property will be ignored during mapping
+     */
+    public function __construct(
+        public ?string $target = null,
+        public ?string $name = null,
+        public ?int $maxDepth = null,
+        public mixed $transformer = null,
+        public ?bool $ignore = null,
+    ) {
+    }
+}

--- a/src/Event/GenerateMapperEvent.php
+++ b/src/Event/GenerateMapperEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Event;
+
+use AutoMapper\Metadata\MapperMetadata;
+
+/**
+ * @internal
+ */
+final class GenerateMapperEvent
+{
+    /**
+     * @param PropertyMetadataEvent[] $properties A list of properties to add to this mapping
+     */
+    public function __construct(
+        public readonly MapperMetadata $mapperMetadata,
+        public $properties = [],
+    ) {
+    }
+}

--- a/src/EventListener/MapToListener.php
+++ b/src/EventListener/MapToListener.php
@@ -9,6 +9,7 @@ use AutoMapper\Event\GenerateMapperEvent;
 use AutoMapper\Event\PropertyMetadataEvent;
 use AutoMapper\Event\SourcePropertyMetadata;
 use AutoMapper\Event\TargetPropertyMetadata;
+use AutoMapper\Exception\BadMapDefinitionException;
 use AutoMapper\Transformer\CallableTransformer;
 use AutoMapper\Transformer\CustomTransformer\CustomModelTransformer;
 use AutoMapper\Transformer\CustomTransformer\CustomModelTransformerInterface;
@@ -76,7 +77,7 @@ final readonly class MapToListener
                 );
 
                 if (isset($event->properties[$property->target->name])) {
-                    // @TODO throw exception
+                    throw new BadMapDefinitionException(sprintf('There is already a MapTo attribute with target "%s" in class "%s".', $property->target->name, $event->mapperMetadata->source));
                 }
 
                 $event->properties[$property->target->name] = $property;

--- a/src/EventListener/MapToListener.php
+++ b/src/EventListener/MapToListener.php
@@ -19,8 +19,9 @@ use AutoMapper\Transformer\CustomTransformer\CustomTransformersRegistry;
 
 final readonly class MapToListener
 {
-    public function __construct(private CustomTransformersRegistry $customTransformersRegistry)
-    {
+    public function __construct(
+        private CustomTransformersRegistry $customTransformersRegistry
+    ) {
     }
 
     public function __invoke(GenerateMapperEvent $event): void
@@ -34,7 +35,7 @@ final readonly class MapToListener
         foreach ($properties as $reflectionProperty) {
             $mapToAttributes = $reflectionProperty->getAttributes(MapTo::class);
 
-            if (empty($mapToAttributes)) {
+            if (0 === \count($mapToAttributes)) {
                 continue;
             }
 
@@ -76,7 +77,7 @@ final readonly class MapToListener
                     $mapToAttributeInstance->ignore,
                 );
 
-                if (isset($event->properties[$property->target->name])) {
+                if (\array_key_exists($property->target->name, $event->properties)) {
                     throw new BadMapDefinitionException(sprintf('There is already a MapTo attribute with target "%s" in class "%s".', $property->target->name, $event->mapperMetadata->source));
                 }
 

--- a/src/EventListener/MapToListener.php
+++ b/src/EventListener/MapToListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\EventListener;
 
+use AutoMapper\Attribute\MapFrom;
 use AutoMapper\Attribute\MapTo;
 use AutoMapper\Event\GenerateMapperEvent;
 use AutoMapper\Event\PropertyMetadataEvent;
@@ -16,6 +17,7 @@ use AutoMapper\Transformer\CustomTransformer\CustomModelTransformerInterface;
 use AutoMapper\Transformer\CustomTransformer\CustomPropertyTransformer;
 use AutoMapper\Transformer\CustomTransformer\CustomPropertyTransformerInterface;
 use AutoMapper\Transformer\CustomTransformer\CustomTransformersRegistry;
+use AutoMapper\Transformer\TransformerInterface;
 
 final readonly class MapToListener
 {
@@ -25,6 +27,16 @@ final readonly class MapToListener
     }
 
     public function __invoke(GenerateMapperEvent $event): void
+    {
+        if ($event->mapperMetadata->sourceReflectionClass === null) {
+            return;
+        }
+
+        $this->setPropertiesFromSource($event);
+        $this->setPropertiesFromTarget($event);
+    }
+
+    private function setPropertiesFromSource(GenerateMapperEvent $event): void
     {
         if ($event->mapperMetadata->sourceReflectionClass === null) {
             return;
@@ -50,57 +62,12 @@ final readonly class MapToListener
                 $sourceProperty = new SourcePropertyMetadata($reflectionProperty->getName());
                 $targetProperty = new TargetPropertyMetadata($mapToAttributeInstance->name ?? $reflectionProperty->getName());
 
-                $transformer = null;
-
-                if ($mapToAttributeInstance->transformer !== null) {
-                    $callableName = null;
-                    $transformerCallable = $mapToAttributeInstance->transformer;
-
-                    if ($transformerCallable instanceof \Closure) {
-                        // This is not supported because we cannot generate code from a closure
-                        // However this should never be possible since attributes does not allow to pass a closure
-                        // Let's keep this check for future proof
-                        throw new BadMapDefinitionException('Closure transformer is not supported.');
-                    }
-
-                    if (\is_string($transformerCallable) && $customTransformer = $this->customTransformersRegistry->getCustomTransformer($transformerCallable)) {
-                        if ($customTransformer instanceof CustomModelTransformerInterface) {
-                            $transformer = new CustomModelTransformer($transformerCallable);
-                        }
-
-                        if ($customTransformer instanceof CustomPropertyTransformerInterface) {
-                            $transformer = new CustomPropertyTransformer($transformerCallable);
-                        }
-                    } elseif (\is_callable($transformerCallable, false, $callableName)) {
-                        $transformer = new CallableTransformer($callableName);
-                    } elseif (\is_string($transformerCallable)) {
-                        // Check the method exist on the class
-                        if (!method_exists($event->mapperMetadata->source, $transformerCallable)) {
-                            if (class_exists($transformerCallable)) {
-                                throw new BadMapDefinitionException(sprintf('Transformer "%s" targeted by MapTo transformer does not exist on class "%s", did you register it ?.', $transformerCallable, $event->mapperMetadata->source));
-                            }
-
-                            throw new BadMapDefinitionException(sprintf('Method "%s" targeted by MapTo transformer does not exist on class "%s".', $transformerCallable, $event->mapperMetadata->source));
-                        }
-
-                        $reflMethod = new \ReflectionMethod($event->mapperMetadata->source, $transformerCallable);
-
-                        if ($reflMethod->isStatic()) {
-                            $transformer = new CallableTransformer($event->mapperMetadata->source . '::' . $transformerCallable);
-                        } else {
-                            $transformer = new CallableTransformer($transformerCallable, true);
-                        }
-                    } else {
-                        throw new BadMapDefinitionException(sprintf('Callable "%s" targeted by MapTo transformer on class "%s" is not valid.', json_encode($transformerCallable), $event->mapperMetadata->source));
-                    }
-                }
-
                 $property = new PropertyMetadataEvent(
                     $event->mapperMetadata,
                     $sourceProperty,
                     $targetProperty,
                     $mapToAttributeInstance->maxDepth,
-                    $transformer,
+                    $this->getTransformerFromMapAttribute($event->mapperMetadata->source, $mapToAttributeInstance),
                     $mapToAttributeInstance->ignore,
                 );
 
@@ -111,5 +78,99 @@ final readonly class MapToListener
                 $event->properties[$property->target->name] = $property;
             }
         }
+    }
+
+    private function setPropertiesFromTarget(GenerateMapperEvent $event): void
+    {
+        if ($event->mapperMetadata->targetReflectionClass === null) {
+            return;
+        }
+
+        $properties = $event->mapperMetadata->targetReflectionClass->getProperties();
+
+        foreach ($properties as $reflectionProperty) {
+            $mapFromAttributes = $reflectionProperty->getAttributes(MapFrom::class);
+
+            if (0 === \count($mapFromAttributes)) {
+                continue;
+            }
+
+            foreach ($mapFromAttributes as $mapFromAttribute) {
+                /** @var MapFrom $mapFromAttributeInstance */
+                $mapFromAttributeInstance = $mapFromAttribute->newInstance();
+
+                if ($mapFromAttributeInstance->source !== null && $event->mapperMetadata->source !== $mapFromAttributeInstance->source) {
+                    continue;
+                }
+
+                $sourceProperty = new SourcePropertyMetadata($mapFromAttributeInstance->name ?? $reflectionProperty->getName());
+                $targetProperty = new TargetPropertyMetadata($reflectionProperty->getName());
+
+                $property = new PropertyMetadataEvent(
+                    $event->mapperMetadata,
+                    $sourceProperty,
+                    $targetProperty,
+                    $mapFromAttributeInstance->maxDepth,
+                    $this->getTransformerFromMapAttribute($event->mapperMetadata->target, $mapFromAttributeInstance),
+                    $mapFromAttributeInstance->ignore,
+                );
+
+                if (\array_key_exists($property->target->name, $event->properties)) {
+                    throw new BadMapDefinitionException(sprintf('There is already a MapTo or MapFrom attribute with target "%s" in class "%s" or class "%s".', $property->target->name, $event->mapperMetadata->source, $event->mapperMetadata->target));
+                }
+
+                $event->properties[$property->target->name] = $property;
+            }
+        }
+    }
+
+    private function getTransformerFromMapAttribute(string $class, MapTo|MapFrom $attribute): ?TransformerInterface
+    {
+        $transformer = null;
+
+        if ($attribute->transformer !== null) {
+            $callableName = null;
+            $transformerCallable = $attribute->transformer;
+
+            if ($transformerCallable instanceof \Closure) {
+                // This is not supported because we cannot generate code from a closure
+                // However this should never be possible since attributes does not allow to pass a closure
+                // Let's keep this check for future proof
+                throw new BadMapDefinitionException('Closure transformer is not supported.');
+            }
+
+            if (\is_string($transformerCallable) && $customTransformer = $this->customTransformersRegistry->getCustomTransformer($transformerCallable)) {
+                if ($customTransformer instanceof CustomModelTransformerInterface) {
+                    $transformer = new CustomModelTransformer($transformerCallable);
+                }
+
+                if ($customTransformer instanceof CustomPropertyTransformerInterface) {
+                    $transformer = new CustomPropertyTransformer($transformerCallable);
+                }
+            } elseif (\is_callable($transformerCallable, false, $callableName)) {
+                $transformer = new CallableTransformer($callableName);
+            } elseif (\is_string($transformerCallable)) {
+                // Check the method exist on the class
+                if (!method_exists($class, $transformerCallable)) {
+                    if (class_exists($transformerCallable)) {
+                        throw new BadMapDefinitionException(sprintf('Transformer "%s" targeted by %s transformer does not exist on class "%s", did you register it ?.', $transformerCallable, $attribute::class, $class));
+                    }
+
+                    throw new BadMapDefinitionException(sprintf('Method "%s" targeted by %s transformer does not exist on class "%s".', $transformerCallable, $attribute::class, $class));
+                }
+
+                $reflMethod = new \ReflectionMethod($class, $transformerCallable);
+
+                if ($reflMethod->isStatic()) {
+                    $transformer = new CallableTransformer($class . '::' . $transformerCallable);
+                } else {
+                    $transformer = new CallableTransformer($transformerCallable, true);
+                }
+            } else {
+                throw new BadMapDefinitionException(sprintf('Callable "%s" targeted by %s transformer on class "%s" is not valid.', json_encode($transformerCallable), $attribute::class, $class));
+            }
+        }
+
+        return $transformer;
     }
 }

--- a/src/EventListener/MapToMapperListener.php
+++ b/src/EventListener/MapToMapperListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\EventListener;
+
+use AutoMapper\Attribute\MapTo;
+use AutoMapper\Event\GenerateMapperEvent;
+use AutoMapper\Event\PropertyMetadataEvent;
+use AutoMapper\Event\SourcePropertyMetadata;
+use AutoMapper\Event\TargetPropertyMetadata;
+
+class MapToMapperListener
+{
+    public function __construct()
+    {
+    }
+
+    public function __invoke(GenerateMapperEvent $event): void
+    {
+        if ($event->mapperMetadata->sourceReflectionClass === null) {
+            return;
+        }
+
+        $properties = $event->mapperMetadata->sourceReflectionClass->getProperties();
+
+        foreach ($properties as $reflectionProperty) {
+            $mapToAttributes = $reflectionProperty->getAttributes(MapTo::class);
+
+            if (empty($mapToAttributes)) {
+                continue;
+            }
+
+            foreach ($mapToAttributes as $mapToAttribute) {
+                /** @var MapTo $mapToAttributeInstance */
+                $mapToAttributeInstance = $mapToAttribute->newInstance();
+
+                if ($mapToAttributeInstance->target !== null && $event->mapperMetadata->target !== $mapToAttributeInstance->target) {
+                    continue;
+                }
+
+                $sourceProperty = new SourcePropertyMetadata($reflectionProperty->getName());
+                $targetProperty = new TargetPropertyMetadata($mapToAttributeInstance->name ?? $reflectionProperty->getName());
+
+                $transformer = null;
+
+                if ($mapToAttributeInstance->transformer !== null) {
+                    // @TODO create transformer
+                }
+
+                $property = new PropertyMetadataEvent(
+                    $event->mapperMetadata,
+                    $sourceProperty,
+                    $targetProperty,
+                    $mapToAttributeInstance->maxDepth,
+                    $transformer,
+                    $mapToAttributeInstance->ignore,
+                );
+
+                if (isset($event->properties[$property->target->name])) {
+                    // @TODO throw exception
+                }
+
+                $event->properties[$property->target->name] = $property;
+            }
+        }
+    }
+}

--- a/src/Exception/BadMapDefinitionException.php
+++ b/src/Exception/BadMapDefinitionException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Exception;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+final class BadMapDefinitionException extends RuntimeException
+{
+}

--- a/src/Metadata/MapperMetadata.php
+++ b/src/Metadata/MapperMetadata.php
@@ -14,10 +14,10 @@ class MapperMetadata
     public string $className;
 
     /** @var \ReflectionClass<object>|null */
-    public ?\ReflectionClass $sourceReflectionClass;
+    public readonly ?\ReflectionClass $sourceReflectionClass;
 
     /** @var \ReflectionClass<object>|null */
-    public ?\ReflectionClass $targetReflectionClass;
+    public readonly ?\ReflectionClass $targetReflectionClass;
 
     /**
      * @param class-string<object>|'array' $source

--- a/src/Metadata/MetadataRegistry.php
+++ b/src/Metadata/MetadataRegistry.php
@@ -10,7 +10,7 @@ use AutoMapper\Event\PropertyMetadataEvent;
 use AutoMapper\Event\SourcePropertyMetadata as SourcePropertyMetadataEvent;
 use AutoMapper\Event\TargetPropertyMetadata as TargetPropertyMetadataEvent;
 use AutoMapper\EventListener\MapToContextListener;
-use AutoMapper\EventListener\MapToMapperListener;
+use AutoMapper\EventListener\MapToListener;
 use AutoMapper\EventListener\Symfony\AdvancedNameConverterListener;
 use AutoMapper\EventListener\Symfony\SerializerGroupListener;
 use AutoMapper\EventListener\Symfony\SerializerIgnoreListener;
@@ -260,7 +260,7 @@ final class MetadataRegistry
         }
 
         $eventDispatcher->addListener(PropertyMetadataEvent::class, new MapToContextListener($reflectionExtractor));
-        $eventDispatcher->addListener(GenerateMapperEvent::class, new MapToMapperListener());
+        $eventDispatcher->addListener(GenerateMapperEvent::class, new MapToListener($customTransformerRegistry));
 
         $propertyInfoExtractor = new PropertyInfoExtractor(
             listExtractors: [$reflectionExtractor],

--- a/src/Metadata/MetadataRegistry.php
+++ b/src/Metadata/MetadataRegistry.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace AutoMapper\Metadata;
 
 use AutoMapper\Configuration;
+use AutoMapper\Event\GenerateMapperEvent;
 use AutoMapper\Event\PropertyMetadataEvent;
 use AutoMapper\Event\SourcePropertyMetadata as SourcePropertyMetadataEvent;
 use AutoMapper\Event\TargetPropertyMetadata as TargetPropertyMetadataEvent;
 use AutoMapper\EventListener\MapToContextListener;
+use AutoMapper\EventListener\MapToMapperListener;
 use AutoMapper\EventListener\Symfony\AdvancedNameConverterListener;
 use AutoMapper\EventListener\Symfony\SerializerGroupListener;
 use AutoMapper\EventListener\Symfony\SerializerIgnoreListener;
@@ -116,6 +118,9 @@ final class MetadataRegistry
 
         $propertyEvents = [];
 
+        $mapperEvent = new GenerateMapperEvent($mapperMetadata);
+        $this->eventDispatcher->dispatch($mapperEvent);
+
         // First get properties from the source
         foreach ($extractor->getProperties($mapperMetadata->source) as $property) {
             $propertyEvent = new PropertyMetadataEvent($mapperMetadata, new SourcePropertyMetadataEvent($property), new TargetPropertyMetadataEvent($property));
@@ -132,6 +137,12 @@ final class MetadataRegistry
 
             $propertyEvent = new PropertyMetadataEvent($mapperMetadata, new SourcePropertyMetadataEvent($property), new TargetPropertyMetadataEvent($property));
 
+            $this->eventDispatcher->dispatch($propertyEvent);
+
+            $propertyEvents[$propertyEvent->target->name] = $propertyEvent;
+        }
+
+        foreach ($mapperEvent->properties as $propertyEvent) {
             $this->eventDispatcher->dispatch($propertyEvent);
 
             $propertyEvents[$propertyEvent->target->name] = $propertyEvent;
@@ -249,6 +260,7 @@ final class MetadataRegistry
         }
 
         $eventDispatcher->addListener(PropertyMetadataEvent::class, new MapToContextListener($reflectionExtractor));
+        $eventDispatcher->addListener(GenerateMapperEvent::class, new MapToMapperListener());
 
         $propertyInfoExtractor = new PropertyInfoExtractor(
             listExtractors: [$reflectionExtractor],

--- a/src/Transformer/CallableTransformer.php
+++ b/src/Transformer/CallableTransformer.php
@@ -13,12 +13,25 @@ use PhpParser\Node\Scalar;
 class CallableTransformer implements TransformerInterface
 {
     public function __construct(
-        private string $callable
+        private string $callable,
+        private bool $callableIsMethodFromSource = false,
     ) {
     }
 
     public function transform(Expr $input, Expr $target, PropertyMetadata $propertyMapping, UniqueVariableScope $uniqueVariableScope, Expr\Variable $source): array
     {
+        if ($this->callableIsMethodFromSource) {
+            $newInput = new Expr\MethodCall(
+                $source,
+                $this->callable,
+                [
+                    new Arg($input),
+                ]
+            );
+
+            return [$newInput, []];
+        }
+
         $newInput = new Expr\FuncCall(
             new Scalar\String_($this->callable),
             [

--- a/src/Transformer/CallableTransformer.php
+++ b/src/Transformer/CallableTransformer.php
@@ -12,8 +12,9 @@ use PhpParser\Node\Scalar;
 
 class CallableTransformer implements TransformerInterface
 {
-    public function __construct(private string $callable)
-    {
+    public function __construct(
+        private string $callable
+    ) {
     }
 
     public function transform(Expr $input, Expr $target, PropertyMetadata $propertyMapping, UniqueVariableScope $uniqueVariableScope, Expr\Variable $source): array

--- a/src/Transformer/CallableTransformer.php
+++ b/src/Transformer/CallableTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Transformer;
+
+use AutoMapper\Generator\UniqueVariableScope;
+use AutoMapper\Metadata\PropertyMetadata;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+
+class CallableTransformer implements TransformerInterface
+{
+    public function __construct(private string $callable)
+    {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMetadata $propertyMapping, UniqueVariableScope $uniqueVariableScope, Expr\Variable $source): array
+    {
+        $newInput = new Expr\FuncCall(
+            new Scalar\String_($this->callable),
+            [
+                new Arg($input),
+            ]
+        );
+
+        return [$newInput, []];
+    }
+}

--- a/src/Transformer/CustomTransformer/CustomTransformersRegistry.php
+++ b/src/Transformer/CustomTransformer/CustomTransformersRegistry.php
@@ -32,6 +32,11 @@ final class CustomTransformersRegistry
         $this->customTransformers[$id] = $customTransformer;
     }
 
+    public function getCustomTransformer(string $id): ?CustomTransformerInterface
+    {
+        return $this->customTransformers[$id] ?? null;
+    }
+
     /**
      * @param Type[] $sourceTypes
      * @param Type[] $targetTypes

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -21,4 +21,15 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
         $this->assertSame('foo', $bar->bar);
         $this->assertSame('foo', $bar->baz);
     }
+
+    public function testMapToArray()
+    {
+        $foo = new FooMapTo('foo');
+        $bar = $this->autoMapper->map($foo, 'array');
+
+        $this->assertIsArray($bar);
+        $this->assertArrayNotHasKey('bar', $bar);
+        $this->assertSame('foo', $bar['baz']);
+        $this->assertSame('FOO', $bar['foo']);
+    }
 }

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -6,8 +6,11 @@ namespace AutoMapper\Tests;
 
 use AutoMapper\Exception\BadMapDefinitionException;
 use AutoMapper\Tests\Fixtures\MapTo\BadMapTo;
+use AutoMapper\Tests\Fixtures\MapTo\BadMapToTransformer;
 use AutoMapper\Tests\Fixtures\MapTo\Bar;
 use AutoMapper\Tests\Fixtures\MapTo\FooMapTo;
+use AutoMapper\Tests\Fixtures\Transformer\CustomTransformer\FooDependency;
+use AutoMapper\Tests\Fixtures\Transformer\CustomTransformer\TransformerWithDependency;
 
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
@@ -27,17 +30,30 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
     public function testMapToArray()
     {
         $foo = new FooMapTo('foo');
+        $this->autoMapper->bindCustomTransformer(new TransformerWithDependency(new FooDependency()));
         $bar = $this->autoMapper->map($foo, 'array');
 
         $this->assertIsArray($bar);
         $this->assertArrayNotHasKey('bar', $bar);
         $this->assertSame('foo', $bar['baz']);
-        $this->assertSame('FOO', $bar['foo']);
+        $this->assertSame('foo', $bar['foo']);
+        $this->assertSame('transformFromIsCallable_foo', $bar['transformFromIsCallable']);
+        $this->assertSame('transformFromStringInstance_foo', $bar['transformFromStringInstance']);
+        $this->assertSame('transformFromStringStatic_foo', $bar['transformFromStringStatic']);
+        $this->assertSame('bar', $bar['transformFromCustomTransformerService']);
     }
 
     public function testBadDefinitionOnSameTargetProperty()
     {
         $foo = new BadMapTo('foo');
+
+        $this->expectException(BadMapDefinitionException::class);
+        $this->autoMapper->map($foo, 'array');
+    }
+
+    public function testBadDefinitionOnTransformer()
+    {
+        $foo = new BadMapToTransformer('foo');
 
         $this->expectException(BadMapDefinitionException::class);
         $this->autoMapper->map($foo, 'array');

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests;
 
+use AutoMapper\Exception\BadMapDefinitionException;
+use AutoMapper\Tests\Fixtures\MapTo\BadMapTo;
 use AutoMapper\Tests\Fixtures\MapTo\Bar;
 use AutoMapper\Tests\Fixtures\MapTo\FooMapTo;
 
@@ -31,5 +33,13 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
         $this->assertArrayNotHasKey('bar', $bar);
         $this->assertSame('foo', $bar['baz']);
         $this->assertSame('FOO', $bar['foo']);
+    }
+
+    public function testBadDefinitionOnSameTargetProperty()
+    {
+        $foo = new BadMapTo('foo');
+
+        $this->expectException(BadMapDefinitionException::class);
+        $this->autoMapper->map($foo, 'array');
     }
 }

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -26,6 +26,7 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
         $this->assertSame('foo', $bar->bar);
         $this->assertSame('foo', $bar->baz);
         $this->assertSame('foo', $bar->from);
+        $this->assertSame('d', $bar->getB());
     }
 
     public function testMapToArray()
@@ -36,6 +37,7 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
 
         $this->assertIsArray($bar);
         $this->assertArrayNotHasKey('bar', $bar);
+        $this->assertArrayNotHasKey('a', $bar);
         $this->assertSame('foo', $bar['baz']);
         $this->assertSame('foo', $bar['foo']);
         $this->assertSame('transformFromIsCallable_foo', $bar['transformFromIsCallable']);

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -25,6 +25,7 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
         $this->assertInstanceOf(Bar::class, $bar);
         $this->assertSame('foo', $bar->bar);
         $this->assertSame('foo', $bar->baz);
+        $this->assertSame('foo', $bar->from);
     }
 
     public function testMapToArray()

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests;
+
+use AutoMapper\Tests\Fixtures\MapTo\Bar;
+use AutoMapper\Tests\Fixtures\MapTo\FooMapTo;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+class AutoMapperMapToTest extends AutoMapperBaseTest
+{
+    public function testMapTo()
+    {
+        $foo = new FooMapTo('foo');
+        $bar = $this->autoMapper->map($foo, Bar::class);
+
+        $this->assertInstanceOf(Bar::class, $bar);
+        $this->assertSame('foo', $bar->bar);
+        $this->assertSame('foo', $bar->baz);
+    }
+}

--- a/tests/Fixtures/MapTo/BadMapTo.php
+++ b/tests/Fixtures/MapTo/BadMapTo.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\MapTo;
+
+use AutoMapper\Attribute\MapTo;
+
+class BadMapTo
+{
+    public function __construct(
+        #[MapTo('array', ignore: true)]
+        #[MapTo('array', ignore: false)]
+        public string $foo
+    ) {
+    }
+}

--- a/tests/Fixtures/MapTo/BadMapToTransformer.php
+++ b/tests/Fixtures/MapTo/BadMapToTransformer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\MapTo;
+
+use AutoMapper\Attribute\MapTo;
+
+class BadMapToTransformer
+{
+    public function __construct(
+        // Not valid because it is not static
+        #[MapTo(transformer: [self::class, 'transformFoo'])]
+        public string $foo
+    ) {
+    }
+
+    public function transformFoo(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Fixtures/MapTo/Bar.php
+++ b/tests/Fixtures/MapTo/Bar.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Fixtures\MapTo;
 
+use AutoMapper\Attribute\MapFrom;
+
 class Bar
 {
     public function __construct(
         public string $bar,
-        public string $baz
+        public string $baz,
+        #[MapFrom(source: FooMapTo::class, name: 'foo')]
+        public string $from,
     ) {
     }
 }

--- a/tests/Fixtures/MapTo/Bar.php
+++ b/tests/Fixtures/MapTo/Bar.php
@@ -8,11 +8,25 @@ use AutoMapper\Attribute\MapFrom;
 
 class Bar
 {
+    #[MapFrom(source: 'array', ignore: true)]
+    private string $b = '';
+
     public function __construct(
         public string $bar,
         public string $baz,
-        #[MapFrom(source: FooMapTo::class, name: 'foo')]
+        #[MapFrom(name: 'foo')]
         public string $from,
     ) {
+    }
+
+    #[MapFrom(source: FooMapTo::class, name: 'd')]
+    public function setB(string $b)
+    {
+        $this->b = $b;
+    }
+
+    public function getB(): string
+    {
+        return $this->b;
     }
 }

--- a/tests/Fixtures/MapTo/Bar.php
+++ b/tests/Fixtures/MapTo/Bar.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\MapTo;
+
+class Bar
+{
+    public function __construct(
+        public string $bar,
+        public string $baz
+    ) {
+    }
+}

--- a/tests/Fixtures/MapTo/FooMapTo.php
+++ b/tests/Fixtures/MapTo/FooMapTo.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\MapTo;
+
+use AutoMapper\Attribute\MapTo;
+
+class FooMapTo
+{
+    public function __construct(
+        #[MapTo(Bar::class, name: 'bar')]
+        #[MapTo(Bar::class, name: 'baz')]
+        public string $foo
+    ) {
+    }
+}

--- a/tests/Fixtures/MapTo/FooMapTo.php
+++ b/tests/Fixtures/MapTo/FooMapTo.php
@@ -10,8 +10,14 @@ class FooMapTo
 {
     public function __construct(
         #[MapTo(Bar::class, name: 'bar')]
-        #[MapTo(Bar::class, name: 'baz')]
+        #[MapTo(name: 'baz')]
+        #[MapTo('array', transformer: self::class . '::testTransform')]
         public string $foo
     ) {
+    }
+
+    public static function testTransform($value)
+    {
+        return strtoupper($value);
     }
 }

--- a/tests/Fixtures/MapTo/FooMapTo.php
+++ b/tests/Fixtures/MapTo/FooMapTo.php
@@ -20,6 +20,17 @@ class FooMapTo
     ) {
     }
 
+    #[MapTo('array', ignore: true)]
+    public function getA(): string
+    {
+        return 'a';
+    }
+
+    public function getD(): string
+    {
+        return 'd';
+    }
+
     public static function transformFromIsCallable($value)
     {
         return 'transformFromIsCallable_' . $value;

--- a/tests/Fixtures/MapTo/FooMapTo.php
+++ b/tests/Fixtures/MapTo/FooMapTo.php
@@ -5,19 +5,33 @@ declare(strict_types=1);
 namespace AutoMapper\Tests\Fixtures\MapTo;
 
 use AutoMapper\Attribute\MapTo;
+use AutoMapper\Tests\Fixtures\Transformer\CustomTransformer\TransformerWithDependency;
 
 class FooMapTo
 {
     public function __construct(
         #[MapTo(Bar::class, name: 'bar')]
         #[MapTo(name: 'baz')]
-        #[MapTo('array', transformer: self::class . '::testTransform')]
+        #[MapTo('array', name: 'transformFromIsCallable', transformer: self::class . '::transformFromIsCallable')]
+        #[MapTo('array', name: 'transformFromStringInstance', transformer: 'transformFromStringInstance')]
+        #[MapTo('array', name: 'transformFromStringStatic', transformer: 'transformFromStringStatic')]
+        #[MapTo('array', name: 'transformFromCustomTransformerService', transformer: TransformerWithDependency::class)]
         public string $foo
     ) {
     }
 
-    public static function testTransform($value)
+    public static function transformFromIsCallable($value)
     {
-        return strtoupper($value);
+        return 'transformFromIsCallable_' . $value;
+    }
+
+    public function transformFromStringInstance($value)
+    {
+        return 'transformFromStringInstance_' . $value;
+    }
+
+    public static function transformFromStringStatic($value)
+    {
+        return 'transformFromStringStatic_' . $value;
     }
 }


### PR DESCRIPTION
Add `#[MapTo]` attribute which allows to : 

 * Add a mapping on a previously not found property
 * Ignore a property during a Map ref #16 
 * Customize the target property ref #34 
 * Allow to use a custom transformer : callable / transformer service ref #28 
 