### PR TITLE
fix: allow unions with several object classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [GH#55](https://github.com/jolicode/automapper/pull/55) Remove most of deprecations in tests
+- [GH#69](https://github.com/jolicode/automapper/pull/69) Allow to handle union types with several objects
 
 ## [8.2.1] - 2024-03-11
 ### Changed

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -29,6 +29,9 @@ use AutoMapper\Tests\Fixtures\HasDateTimeInterfaceWithImmutableInstance;
 use AutoMapper\Tests\Fixtures\HasDateTimeInterfaceWithMutableInstance;
 use AutoMapper\Tests\Fixtures\HasDateTimeInterfaceWithNullValue;
 use AutoMapper\Tests\Fixtures\HasDateTimeWithNullValue;
+use AutoMapper\Tests\Fixtures\ObjectsUnion\Bar;
+use AutoMapper\Tests\Fixtures\ObjectsUnion\Foo;
+use AutoMapper\Tests\Fixtures\ObjectsUnion\ObjectsUnionProperty;
 use AutoMapper\Tests\Fixtures\ObjectWithDateTime;
 use AutoMapper\Tests\Fixtures\Order;
 use AutoMapper\Tests\Fixtures\PetOwner;
@@ -1326,6 +1329,19 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertSame(
             [],
             $this->autoMapper->map(new BuiltinClass(new \DateInterval('P1Y')), 'array')
+        );
+    }
+
+    public function testObjectsUnion(): void
+    {
+        self::assertSame(
+            ['prop' => ['bar' => 'bar']],
+            $this->autoMapper->map(new ObjectsUnionProperty(new Bar('bar')), 'array')
+        );
+
+        self::assertSame(
+            ['prop' => ['foo' => 'foo']],
+            $this->autoMapper->map(new ObjectsUnionProperty(new Foo('foo')), 'array')
         );
     }
 }

--- a/tests/Fixtures/ObjectsUnion/Bar.php
+++ b/tests/Fixtures/ObjectsUnion/Bar.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\ObjectsUnion;
+
+final readonly class Bar
+{
+    public function __construct(
+        public string $bar
+    ) {
+    }
+}

--- a/tests/Fixtures/ObjectsUnion/Foo.php
+++ b/tests/Fixtures/ObjectsUnion/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\ObjectsUnion;
+
+final readonly class Foo
+{
+    public function __construct(
+        public string $foo
+    ) {
+    }
+}

--- a/tests/Fixtures/ObjectsUnion/ObjectsUnionProperty.php
+++ b/tests/Fixtures/ObjectsUnion/ObjectsUnionProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures\ObjectsUnion;
+
+final readonly class ObjectsUnionProperty
+{
+    public function __construct(
+        public Foo|Bar $prop
+    ) {
+    }
+}


### PR DESCRIPTION
before this PR, an error would have occurred when trying to map a property which is an union of several objects.

This code:
```php
private Foo|Bar $prop
```

was generating this mapper:
```php
if (\AutoMapper\MapperContext::isAllowedAttribute($context, 'prop', isset($value->prop))) {
    $value_1 = $value->prop;
    if (is_object($value->prop)) {
        // map form Foo
    }
    if (is_object($value->prop)) {
        // map form Bar
    }
    $result['prop'] = $value_1;
}
```
so it never tried to handle case when `$prop` is `Bar`

now, it adds an `instanceof`:
```php
if (\AutoMapper\MapperContext::isAllowedAttribute($context, 'prop', isset($value->prop))) {
    $value_1 = $value->prop;
    if (is_object($value->prop) && $value->prop instanceof Foo) {
        // map form Foo
    }
    if (is_object($value->prop) && $value6->prop instanceof Bar) {
        // map form Bar
    }
    $result['prop'] = $value_1;
}
```