### PR TITLE
fix(transformer): check class exists when checking reflection class in object transformer factory

### DIFF
--- a/src/Transformer/ObjectTransformerFactory.php
+++ b/src/Transformer/ObjectTransformerFactory.php
@@ -62,6 +62,10 @@ final class ObjectTransformerFactory extends AbstractUniqueTypeTransformerFactor
             return true;
         }
 
+        if (!class_exists($class)) {
+            return false;
+        }
+
         $reflectionClass = new \ReflectionClass($class);
 
         if ($reflectionClass->isInternal()) {


### PR DESCRIPTION
This may happens than extractor give "special" classes (thing like a template) for the moment we don't support this, but at least don't throw error in this case