### PR TITLE
feat(map-to): allow map to / from attribute in class when declaring a transformer and a name

### DIFF
--- a/src/Attribute/MapFrom.php
+++ b/src/Attribute/MapFrom.php
@@ -7,7 +7,7 @@ namespace AutoMapper\Attribute;
 /**
  * Configures a property to map from.
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS)]
 final readonly class MapFrom
 {
     /**

--- a/src/Attribute/MapTo.php
+++ b/src/Attribute/MapTo.php
@@ -7,7 +7,7 @@ namespace AutoMapper\Attribute;
 /**
  * Configures a property to map to.
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE | \Attribute::TARGET_CLASS)]
 final readonly class MapTo
 {
     /**

--- a/src/Generator/CreateTargetStatementsGenerator.php
+++ b/src/Generator/CreateTargetStatementsGenerator.php
@@ -9,7 +9,7 @@ use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
 use AutoMapper\MapperContext;
 use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\PropertyMetadata;
-use AutoMapper\Transformer\PropertyTransformer\PropertyTransformer;
+use AutoMapper\Transformer\AllowNullValueTransformerInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -200,7 +200,7 @@ final readonly class CreateTargetStatementsGenerator
         $fieldValueExpr = $propertyMetadata->source->accessor?->getExpression($variableRegistry->getSourceInput());
 
         if (null === $fieldValueExpr) {
-            if (!($propertyMetadata->transformer instanceof PropertyTransformer)) {
+            if (!($propertyMetadata->transformer instanceof AllowNullValueTransformerInterface)) {
                 return null;
             }
 

--- a/src/Generator/PropertyStatementsGenerator.php
+++ b/src/Generator/PropertyStatementsGenerator.php
@@ -7,8 +7,8 @@ namespace AutoMapper\Generator;
 use AutoMapper\Extractor\WriteMutator;
 use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\PropertyMetadata;
+use AutoMapper\Transformer\AllowNullValueTransformerInterface;
 use AutoMapper\Transformer\AssignedByReferenceTransformerInterface;
-use AutoMapper\Transformer\PropertyTransformer\PropertyTransformer;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -32,7 +32,7 @@ final readonly class PropertyStatementsGenerator
      */
     public function generate(GeneratorMetadata $metadata, PropertyMetadata $propertyMetadata): array
     {
-        if ($propertyMetadata->shouldIgnoreProperty()) {
+        if ($propertyMetadata->ignored) {
             return [];
         }
 
@@ -40,7 +40,7 @@ final readonly class PropertyStatementsGenerator
         $fieldValueExpr = $propertyMetadata->source->accessor?->getExpression($variableRegistry->getSourceInput());
 
         if (null === $fieldValueExpr) {
-            if (!($propertyMetadata->transformer instanceof PropertyTransformer)) {
+            if (!($propertyMetadata->transformer instanceof AllowNullValueTransformerInterface)) {
                 return [];
             }
 

--- a/src/Generator/Shared/DiscriminatorStatementsGenerator.php
+++ b/src/Generator/Shared/DiscriminatorStatementsGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Generator\Shared;
 
 use AutoMapper\Metadata\GeneratorMetadata;
-use AutoMapper\Transformer\PropertyTransformer\PropertyTransformer;
+use AutoMapper\Transformer\AllowNullValueTransformerInterface;
 use AutoMapper\Transformer\TransformerInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -93,7 +93,7 @@ final readonly class DiscriminatorStatementsGenerator
         $fieldValueExpr = $propertyMetadata->source->accessor?->getExpression($variableRegistry->getSourceInput());
 
         if (null === $fieldValueExpr) {
-            if (!($propertyMetadata->transformer instanceof PropertyTransformer)) {
+            if (!($propertyMetadata->transformer instanceof AllowNullValueTransformerInterface)) {
                 return [];
             }
 

--- a/src/Metadata/MetadataRegistry.php
+++ b/src/Metadata/MetadataRegistry.php
@@ -208,16 +208,12 @@ final class MetadataRegistry
                 $propertyMappedEvent->transformer = $transformer;
             }
 
-            if (null === $propertyMappedEvent->ignored) {
-                $propertyMappedEvent->ignored = false;
-            }
-
             $propertiesMapping[] = new PropertyMetadata(
                 $sourcePropertyMetadata,
                 $targetPropertyMetadata,
                 $propertyMappedEvent->types,
                 $propertyMappedEvent->transformer,
-                $propertyMappedEvent->ignored,
+                $propertyMappedEvent->ignored ?? false,
                 $propertyMappedEvent->maxDepth,
                 $propertyMappedEvent->if,
             );

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -20,14 +20,9 @@ final class PropertyMetadata
         public readonly TargetPropertyMetadata $target,
         public readonly TypesMatching $types,
         public TransformerInterface $transformer,
-        public bool $isIgnored = false,
+        public bool $ignored = false,
         public ?int $maxDepth = null,
         public ?string $if = null,
     ) {
-    }
-
-    public function shouldIgnoreProperty(): bool
-    {
-        return !$this->target->writeMutator || $this->isIgnored;
     }
 }

--- a/src/Transformer/AllowNullValueTransformerInterface.php
+++ b/src/Transformer/AllowNullValueTransformerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Transformer;
+
+/**
+ * Flag transformer interface to allow null value.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ *
+ * @internal
+ */
+interface AllowNullValueTransformerInterface
+{
+}

--- a/src/Transformer/CallableTransformer.php
+++ b/src/Transformer/CallableTransformer.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Scalar;
 /**
  * @internal
  */
-class CallableTransformer implements TransformerInterface
+class CallableTransformer implements TransformerInterface, AllowNullValueTransformerInterface
 {
     public function __construct(
         private string $callable,

--- a/src/Transformer/PropertyTransformer/PropertyTransformer.php
+++ b/src/Transformer/PropertyTransformer/PropertyTransformer.php
@@ -6,6 +6,7 @@ namespace AutoMapper\Transformer\PropertyTransformer;
 
 use AutoMapper\Generator\UniqueVariableScope;
 use AutoMapper\Metadata\PropertyMetadata;
+use AutoMapper\Transformer\AllowNullValueTransformerInterface;
 use AutoMapper\Transformer\TransformerInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -14,7 +15,7 @@ use PhpParser\Node\Scalar;
 /**
  * @internal
  */
-final readonly class PropertyTransformer implements TransformerInterface
+final readonly class PropertyTransformer implements TransformerInterface, AllowNullValueTransformerInterface
 {
     public function __construct(
         private string $propertyTransformerId,

--- a/tests/AutoMapperMapToTest.php
+++ b/tests/AutoMapperMapToTest.php
@@ -41,6 +41,7 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
         $this->assertArrayNotHasKey('a', $bar);
         $this->assertSame('foo', $bar['baz']);
         $this->assertSame('foo', $bar['foo']);
+        $this->assertSame('external', $bar['externalProperty']);
         $this->assertSame('transformFromIsCallable_foo', $bar['transformFromIsCallable']);
         $this->assertSame('transformFromStringInstance_foo', $bar['transformFromStringInstance']);
         $this->assertSame('transformFromStringStatic_foo', $bar['transformFromStringStatic']);
@@ -51,7 +52,6 @@ class AutoMapperMapToTest extends AutoMapperBaseTest
         $this->assertSame('if', $bar['ifCallableOther']);
 
         $foo = new FooMapTo('bar');
-        $this->autoMapper->bindCustomTransformer(new TransformerWithDependency(new FooDependency()));
         $bar = $this->autoMapper->map($foo, 'array');
 
         $this->assertIsArray($bar);

--- a/tests/Fixtures/MapTo/FooMapTo.php
+++ b/tests/Fixtures/MapTo/FooMapTo.php
@@ -7,6 +7,7 @@ namespace AutoMapper\Tests\Fixtures\MapTo;
 use AutoMapper\Attribute\MapTo;
 use AutoMapper\Tests\Fixtures\Transformer\CustomTransformer\TransformerWithDependency;
 
+#[MapTo('array', name: 'externalProperty', transformer: 'transformExternalProperty')]
 class FooMapTo
 {
     public function __construct(
@@ -66,5 +67,10 @@ class FooMapTo
     public function shouldMapNotStatic(): bool
     {
         return $this->foo === 'foo';
+    }
+
+    public function transformExternalProperty($value)
+    {
+        return 'external';
     }
 }


### PR DESCRIPTION
This allow to declare a MapTo / MapFrom in the class, useful when there is no relation to a field, in the case transformer will use the source object