### PR TITLE
feat(loader): add reload strategy, rewamp hot_reload

### DIFF
--- a/docs/bundle/configuration.md
+++ b/docs/bundle/configuration.md
@@ -19,10 +19,13 @@ automapper:
     enabled: false
     only_registered_mapping: false
     priority: 1000
+  loader:
+    eval: false
+    cache_dir: "%kernel.cache_dir%/automapper"
+    reload_strategy: "always"
   serializer: true
   api_platform: false
   name_converter: null
-  cache_dir: "%kernel.cache_dir%/automapper"
   mappings:
     mappers:
       - source: AutoMapper\Bundle\Tests\Fixtures\User
@@ -45,7 +48,7 @@ automapper:
   partial mapping, if you don't use this feature set it to false as it will improve the performance;
 * `auto_register` (default: `true`): If the bundle should auto register the mappers in the container when it does not
   exist, when set to `false` you have to register the mappers manually using the `mapping` option, this option is useful
-  when you cannot write to the disk and you want to use the cache warmup;
+  when you cannot write to the disk, and you want to use the cache warmup;
 * `map_private_properties` (default: `true`): If the mapper should map private properties;
 * `allow_readonly_target_to_populate` (default: `false`): Will throw an exception if you use a readonly class as target
   to populate if set to `false`.
@@ -53,6 +56,15 @@ automapper:
     * `enabled` (default: `false`): If the normalizer should be enabled;
     * `only_registered_mapping` (default: `false`): If the normalizer should only use the registered mapping;
     * `priority` (default: `1000`): The priority of the normalizer, the higher the value the higher the priority;
+* `loader`:
+    * `eval` (default: `false`): If the loader should use the eval function to load the mappers, this is useful when
+      you cannot write to the disk;
+    * `cache_dir` (default: `%kernel.cache_dir%/automapper`): The directory where the loader should write the mappers;
+    * `reload_strategy` (default: `always` when `%kernel.debug%` is true, `never` otherwise): The strategy to use to 
+  generate the mappers between each request, can be `always`, `never` or `on_change`:
+        * `always` will generate the mappers at each request;
+        * `never` will generate them only if they don't exist;
+        * `on_change` will generate the mappers only if the source or target class has changed since the last generation;
 * `serializer` (default: `true` if the symfony/serializer is available, false otherwise): A boolean which indicate
   if we use the attribute of the symfony/serializer during the mapping, this only apply to the `#[Groups]`, `#[MaxDepth]`,
   `#[Ignore]` and `#[DiscriminatorMap]` attributes;
@@ -60,8 +72,6 @@ automapper:
 inject extra data (json ld) in the mappers when we map a Resource class to or from an array.
 * `name_converter` (default: `null`): A service id which implement the `AdvancedNameConverterInterface` from the symfony/serializer,
   this name converter will be used when mapping from an array to an object and vice versa;
-* `cache_dir` (default: `%kernel.cache_dir%/automapper`): This setting allows you to customize the output directory
-  for generated mappers;
 * `mappings`: Allow to auto register the mappers for warmup, and selecting them to normalizer if wanted
     * `mappers`: A list of mapping to register, each mapping should have a `source` and a `target` key, and can have
       a `reverse` key to also register the reverse mapping. 

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -20,10 +20,6 @@ use PhpParser\PrettyPrinterAbstract;
  */
 final class FileLoader implements ClassLoaderInterface
 {
-    public const RELOAD_ALWAYS = 'always';
-    public const RELOAD_NEVER = 'never';
-    public const RELOAD_ON_CHANGE = 'on_change';
-
     private readonly PrettyPrinterAbstract $printer;
 
     /** @var array<class-string, string>|null */
@@ -33,7 +29,7 @@ final class FileLoader implements ClassLoaderInterface
         private readonly MapperGenerator $generator,
         private readonly MetadataFactory $metadataFactory,
         private readonly string $directory,
-        private readonly string $reloadStrategy = self::RELOAD_ON_CHANGE,
+        private readonly FileReloadStrategy $reloadStrategy = FileReloadStrategy::ON_CHANGE,
     ) {
         $this->printer = new Standard();
     }
@@ -43,7 +39,7 @@ final class FileLoader implements ClassLoaderInterface
         $className = $mapperMetadata->className;
         $classPath = $this->directory . \DIRECTORY_SEPARATOR . $className . '.php';
 
-        if ($this->reloadStrategy === self::RELOAD_NEVER && file_exists($classPath)) {
+        if ($this->reloadStrategy === FileReloadStrategy::NEVER && file_exists($classPath)) {
             require $classPath;
 
             return;
@@ -51,7 +47,7 @@ final class FileLoader implements ClassLoaderInterface
 
         $shouldBuildMapper = true;
 
-        if ($this->reloadStrategy === self::RELOAD_ON_CHANGE) {
+        if ($this->reloadStrategy === FileReloadStrategy::ON_CHANGE) {
             $registry = $this->getRegistry();
             $hash = $mapperMetadata->getHash();
             $shouldBuildMapper = !isset($registry[$className]) || $registry[$className] !== $hash || !file_exists($classPath);
@@ -86,7 +82,7 @@ final class FileLoader implements ClassLoaderInterface
 
         $this->write($classPath, "<?php\n\n" . $classCode . "\n");
 
-        if ($this->reloadStrategy === self::RELOAD_ON_CHANGE) {
+        if ($this->reloadStrategy === FileReloadStrategy::ON_CHANGE) {
             $this->addHashToRegistry($className, $mapperMetadata->getHash());
         }
 

--- a/src/Loader/FileReloadStrategy.php
+++ b/src/Loader/FileReloadStrategy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Loader;
+
+enum FileReloadStrategy: string
+{
+    case ALWAYS = 'always';
+    case NEVER = 'never';
+    case ON_CHANGE = 'on_change';
+}

--- a/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
@@ -11,6 +11,7 @@ use AutoMapper\EventListener\Symfony\AdvancedNameConverterListener;
 use AutoMapper\Loader\ClassLoaderInterface;
 use AutoMapper\Loader\EvalLoader;
 use AutoMapper\Loader\FileLoader;
+use AutoMapper\Loader\FileReloadStrategy;
 use AutoMapper\Normalizer\AutoMapperNormalizer;
 use AutoMapper\Symfony\Bundle\CacheWarmup\CacheWarmer;
 use AutoMapper\Transformer\PropertyTransformer\PropertyTransformerInterface;
@@ -71,7 +72,8 @@ class AutoMapperExtension extends Extension
             ;
         } else {
             $isDebug = $container->getParameter('kernel.debug');
-            $generateStrategy = $config['loader']['reload_strategy'] ?? $isDebug ? FileLoader::RELOAD_ALWAYS : FileLoader::RELOAD_NEVER;
+            $generateStrategy = $config['loader']['reload_strategy'] ?? $isDebug ? FileReloadStrategy::ALWAYS->value : FileReloadStrategy::NEVER->value;
+            $generateStrategy = FileReloadStrategy::tryFrom($generateStrategy);
 
             $container
                 ->getDefinition(FileLoader::class)

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Symfony\Bundle\DependencyInjection;
 
 use AutoMapper\ConstructorStrategy;
+use AutoMapper\Loader\FileLoader;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -22,7 +23,6 @@ readonly class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('class_prefix')->defaultValue('Symfony_Mapper_')->end()
-                ->booleanNode('eval')->defaultFalse()->end()
                 ->enumNode('constructor_strategy')
                     ->values(array_map(fn (ConstructorStrategy $strategy) => $strategy->value, ConstructorStrategy::cases()))
                     ->defaultValue(ConstructorStrategy::AUTO->value)
@@ -43,15 +43,18 @@ readonly class Configuration implements ConfigurationInterface
                 ->booleanNode('serializer')->defaultValue(interface_exists(SerializerInterface::class))->end()
                 ->booleanNode('api_platform')->defaultFalse()->end()
                 ->scalarNode('name_converter')->defaultNull()->end()
-                ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
+                ->arrayNode('loader')
+                    ->children()
+                        ->booleanNode('eval')->defaultFalse()->end()
+                        ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
+                        ->enumNode('reload_strategy')->values([FileLoader::RELOAD_ALWAYS, FileLoader::RELOAD_ON_CHANGE, FileLoader::RELOAD_NEVER])->end()
+                    ->end()
+                    ->addDefaultsIfNotSet()
+                ->end()
                 ->scalarNode('date_time_format')->defaultValue(\DateTimeInterface::RFC3339)->end()
-                ->booleanNode('hot_reload')->defaultValue('%kernel.debug%')->end()
                 ->booleanNode('map_private_properties')->defaultFalse()->end()
                 ->arrayNode('mapping')
                     ->children()
-                        ->arrayNode('paths')
-                            ->scalarPrototype()->end()
-                        ->end()
                         ->arrayNode('mappers')
                             ->arrayPrototype()
                                 ->children()

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Symfony\Bundle\DependencyInjection;
 
 use AutoMapper\ConstructorStrategy;
-use AutoMapper\Loader\FileLoader;
+use AutoMapper\Loader\FileReloadStrategy;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -47,7 +47,7 @@ readonly class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('eval')->defaultFalse()->end()
                         ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
-                        ->enumNode('reload_strategy')->values([FileLoader::RELOAD_ALWAYS, FileLoader::RELOAD_ON_CHANGE, FileLoader::RELOAD_NEVER])->end()
+                        ->enumNode('reload_strategy')->values(array_map(fn (FileReloadStrategy $value) => $value->value, FileReloadStrategy::cases()))->defaultNull()->end()
                     ->end()
                     ->addDefaultsIfNotSet()
                 ->end()

--- a/src/Symfony/Bundle/config/automapper.php
+++ b/src/Symfony/Bundle/config/automapper.php
@@ -13,7 +13,6 @@ use AutoMapper\Loader\ClassLoaderInterface;
 use AutoMapper\Loader\EvalLoader;
 use AutoMapper\Loader\FileLoader;
 use AutoMapper\Metadata\MetadataFactory;
-use AutoMapper\Metadata\MetadataRegistry;
 use AutoMapper\Provider\ProviderRegistry;
 use AutoMapper\Symfony\ExpressionLanguageProvider;
 use AutoMapper\Transformer\PropertyTransformer\PropertyTransformerRegistry;
@@ -24,7 +23,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service(ClassLoaderInterface::class),
                 service(PropertyTransformerRegistry::class),
-                service(MetadataRegistry::class),
+                service('automapper.config_mapping_registry'),
                 service(ProviderRegistry::class),
                 service(ExpressionLanguageProvider::class),
             ])

--- a/src/Symfony/Bundle/config/metadata.php
+++ b/src/Symfony/Bundle/config/metadata.php
@@ -9,7 +9,6 @@ use AutoMapper\Extractor\FromSourceMappingExtractor;
 use AutoMapper\Extractor\FromTargetMappingExtractor;
 use AutoMapper\Extractor\SourceTargetMappingExtractor;
 use AutoMapper\Metadata\MetadataFactory;
-use AutoMapper\Metadata\MetadataRegistry;
 use AutoMapper\Transformer\TransformerFactoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -39,11 +38,6 @@ return static function (ContainerConfigurator $container) {
                 service('automapper.property_info.reflection_extractor'),
             ])
 
-        ->set(MetadataRegistry::class)
-            ->args([
-                service(Configuration::class),
-            ])
-
         ->set(MetadataFactory::class)
             ->args([
                 service(Configuration::class),
@@ -52,7 +46,7 @@ return static function (ContainerConfigurator $container) {
                 service(FromTargetMappingExtractor::class),
                 service(TransformerFactoryInterface::class),
                 service(EventDispatcherInterface::class),
-                service(MetadataRegistry::class),
+                service('automapper.config_mapping_registry'),
             ])
     ;
 };

--- a/tests/Bundle/Resources/config/packages/automapper.yaml
+++ b/tests/Bundle/Resources/config/packages/automapper.yaml
@@ -2,6 +2,9 @@ automapper:
   normalizer:
     enabled: true
     only_registered_mapping: true
+  loader:
+    eval: false
+    reload_strategy: 'always'
   api_platform: true
   name_converter: AutoMapper\Tests\Bundle\Resources\App\Service\IdNameConverter
   map_private_properties: false


### PR DESCRIPTION
This replace the `hot_reload` with a strategy that also allows to always generate the mappers even if no change.

This is useful for us when we change something that could not be detected, this will also defnitely be useful for users in debug env when we will collect metadata for generator, this will avoid collecting only on the first "request" and avoid confusion.

Never strategy is the default one in non debug for further optimization.
