### PR TITLE
Lazy mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "symfony/property-info": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "phpdocumentor/type-resolver": "^1.7",
-        "phpstan/phpdoc-parser": "^1.13 || ^2.0"
+        "phpstan/phpdoc-parser": "^1.13 || ^2.0",
+        "symfony/var-exporter": "^6.4 || ^7.0"
     },
     "require-dev": {
         "api-platform/core": "^3.0.4",

--- a/src/Generator/CreateTargetStatementsGenerator.php
+++ b/src/Generator/CreateTargetStatementsGenerator.php
@@ -8,14 +8,17 @@ use AutoMapper\Exception\CompileException;
 use AutoMapper\Exception\MissingConstructorArgumentsException;
 use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
 use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
+use AutoMapper\Lazy\LazyMap;
 use AutoMapper\MapperContext;
 use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\PropertyMetadata;
 use AutoMapper\Transformer\AllowNullValueTransformerInterface;
 use PhpParser\Node\Arg;
+use PhpParser\Node\ClosureUse;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Param;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
 use PhpParser\Parser;
@@ -49,24 +52,117 @@ final readonly class CreateTargetStatementsGenerator
      * }
      * ```
      */
-    public function generate(GeneratorMetadata $metadata, VariableRegistry $variableRegistry): Stmt
+    public function generate(GeneratorMetadata $metadata, VariableRegistry $variableRegistry, bool $callDoConstruct): Stmt
     {
         $createObjectStatements = [];
 
+        $createObjectStatements[] = $this->lazyLoadStatement($metadata, $variableRegistry, $callDoConstruct);
         $createObjectStatements[] = $this->targetAsArray($metadata);
         $createObjectStatements[] = $this->sourceAndTargetAsStdClass($metadata);
         $createObjectStatements[] = $this->targetAsStdClass($metadata);
         $createObjectStatements = [...$createObjectStatements, ...$this->discriminatorStatementsGeneratorSource->createTargetStatements($metadata)];
         $createObjectStatements = [...$createObjectStatements, ...$this->discriminatorStatementsGeneratorTarget->createTargetStatements($metadata)];
-        $createObjectStatements = [...$createObjectStatements, ...$this->constructorArguments($metadata)];
+        $createObjectStatements[] = $this->lazyLoadStatement($metadata, $variableRegistry, $callDoConstruct);
         $createObjectStatements[] = $this->cachedReflectionStatementsGenerator->createTargetStatement($metadata);
         $createObjectStatements[] = $this->constructorWithoutArgument($metadata);
+
+        if ($callDoConstruct) {
+            $createObjectStatements[] = $this->doConstructStatement($variableRegistry);
+        }
 
         $createObjectStatements = array_values(array_filter($createObjectStatements));
 
         return new Stmt\If_(new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('null')), $variableRegistry->getResult()), [
             'stmts' => $createObjectStatements,
         ]);
+    }
+
+    private function lazyLoadStatement(GeneratorMetadata $metadata, VariableRegistry $variableRegistry, bool $callDoConstruct): ?Stmt
+    {
+        /** @var class-string<ClosureUse> $closureUseClass */
+        $closureUseClass = class_exists(ClosureUse::class) ? ClosureUse::class : Arg::class;
+        $doMapStmt = new Stmt\Expression(
+            new Expr\MethodCall(
+                new Expr\Variable('this'),
+                'doMap',
+                [
+                    new Arg($variableRegistry->getSourceInput()),
+                    new Arg($variableRegistry->getResult()),
+                    new Arg($variableRegistry->getContext()),
+                ],
+            )
+        );
+
+        if ($metadata->mapperMetadata->lazyGhostClassName === null) {
+            if ($metadata->mapperMetadata->target === 'array') {
+                return new Stmt\If_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'shouldLazyLoad', [
+                    new Arg($variableRegistry->getContext()),
+                ]), [
+                    'stmts' => [
+                        new Stmt\Expression(new Expr\Assign($variableRegistry->getResult(), new Expr\New_(
+                            new Name\FullyQualified(LazyMap::class), [
+                                new Arg(new Expr\Closure([
+                                    'params' => [
+                                        new Param($variableRegistry->getResult(), byRef: true),
+                                    ],
+                                    'stmts' => [$doMapStmt],
+                                    'uses' => [
+                                        new $closureUseClass($variableRegistry->getSourceInput()),
+                                        new $closureUseClass($variableRegistry->getContext()),
+                                    ],
+                                ])),
+                            ]
+                        ))),
+                        new Stmt\Return_($variableRegistry->getResult()),
+                    ],
+                ]);
+            }
+
+            return null;
+        }
+
+        $closureStatements = [];
+
+        if ($callDoConstruct) {
+            $closureStatements[] = $this->doConstructStatement($variableRegistry);
+        }
+
+        $closureStatements[] = $doMapStmt;
+
+        return new Stmt\If_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'shouldLazyLoad', [
+            new Arg($variableRegistry->getContext()),
+        ]), [
+            'stmts' => [
+                new Stmt\Expression(new Expr\Assign($variableRegistry->getResult(), new Expr\StaticCall(new Name\FullyQualified($metadata->mapperMetadata->lazyGhostClassName), 'createLazyGhost', [
+                    new Arg(new Expr\Closure([
+                        'params' => [
+                            new Param($variableRegistry->getResult()),
+                        ],
+                        'stmts' => $closureStatements,
+                        'uses' => [
+                            new $closureUseClass($variableRegistry->getSourceInput()),
+                            new $closureUseClass($variableRegistry->getContext()),
+                        ],
+                    ])),
+                ]))),
+                new Stmt\Return_($variableRegistry->getResult()),
+            ],
+        ]);
+    }
+
+    private function doConstructStatement(VariableRegistry $variableRegistry): Stmt
+    {
+        return new Stmt\Expression(
+            new Expr\MethodCall(
+                new Expr\Variable('this'),
+                'doConstruct',
+                [
+                    new Arg($variableRegistry->getSourceInput()),
+                    new Arg($variableRegistry->getResult()),
+                    new Arg($variableRegistry->getContext()),
+                ],
+            )
+        );
     }
 
     private function targetAsArray(GeneratorMetadata $metadata): ?Stmt
@@ -107,7 +203,7 @@ final readonly class CreateTargetStatementsGenerator
     /**
      * @return list<Stmt>
      */
-    private function constructorArguments(GeneratorMetadata $metadata): array
+    public function getConstructStatements(GeneratorMetadata $metadata): array
     {
         if (!$metadata->isTargetUserDefined()) {
             return [];
@@ -145,12 +241,13 @@ final readonly class CreateTargetStatementsGenerator
         /*
          * Create object with named constructor arguments
          *
-         * $result = new Foo(foo: $constructArg1, bar: $constructArg2, ...);
+         * $result->__construct(foo: $constructArg1, bar: $constructArg2, ...); // If lazy ghost class is available
          */
         $createObjectStatements[] = new Stmt\Expression(
-            new Expr\Assign(
+            new Expr\MethodCall(
                 $metadata->variableRegistry->getResult(),
-                new Expr\New_(new Name\FullyQualified($metadata->mapperMetadata->target), $constructArguments)
+                '__construct',
+                $constructArguments,
             )
         );
 
@@ -308,6 +405,10 @@ final readonly class CreateTargetStatementsGenerator
     {
         if (!$metadata->isTargetUserDefined()
         ) {
+            return null;
+        }
+
+        if ($metadata->mapperMetadata->lazyGhostClassName !== null) {
             return null;
         }
 

--- a/src/Generator/MapMethodStatementsGenerator.php
+++ b/src/Generator/MapMethodStatementsGenerator.php
@@ -41,22 +41,17 @@ final readonly class MapMethodStatementsGenerator
     }
 
     /**
-     * @return list<Stmt>
+     * @return array{0: list<Stmt>, 1: list<Stmt>, 2: list<Stmt>}
      */
-    public function getStatements(GeneratorMetadata $metadata): array
+    public function getMappingStatements(GeneratorMetadata $metadata): array
     {
-        $variableRegistry = $metadata->variableRegistry;
-
-        $statements = [$this->ifSourceIsNullReturnNull($metadata)];
-        $statements = [...$statements, ...$this->handleCircularReference($metadata)];
-        $statements = [...$statements, ...$this->initializeTargetToPopulate($metadata)];
-        $statements = [...$statements, ...$this->initializeTargetFromProvider($metadata)];
-        $statements[] = $this->createObjectStatementsGenerator->generate($metadata, $variableRegistry);
-
-        $addedDependenciesStatements = $this->handleDependencies($metadata);
-
+        // Statements to be executed to construct the object with the constructor
+        $constructorStatements = $this->createObjectStatementsGenerator->getConstructStatements($metadata);
+        // Statements to be executed if the target is populated
         $duplicatedStatements = [];
+        // Statements to be executed after the constructor
         $setterStatements = [];
+
         foreach ($metadata->propertiesMetadata as $propertyMetadata) {
             /**
              * This is the main loop to map the properties from the source to the target, there is 3 main steps in order to generate this code :.
@@ -91,6 +86,26 @@ final readonly class MapMethodStatementsGenerator
             }
         }
 
+        return [$constructorStatements, $duplicatedStatements, $setterStatements];
+    }
+
+    /**
+     * @param list<Stmt> $duplicatedStatements
+     *
+     * @return list<Stmt>
+     */
+    public function getStatements(GeneratorMetadata $metadata, array $duplicatedStatements, bool $callDoConstruct): array
+    {
+        $variableRegistry = $metadata->variableRegistry;
+
+        $statements = [$this->ifSourceIsNullReturnNull($metadata)];
+        $statements = [...$statements, ...$this->handleCircularReference($metadata)];
+        $statements = [...$statements, ...$this->initializeTargetToPopulate($metadata)];
+        $statements = [...$statements, ...$this->initializeTargetFromProvider($metadata)];
+        $statements[] = $this->createObjectStatementsGenerator->generate($metadata, $variableRegistry, $callDoConstruct);
+
+        $addedDependenciesStatements = $this->handleDependencies($metadata);
+
         if (\count($duplicatedStatements) > 0 && \count($metadata->getPropertiesInConstructor())) {
             /*
              * Generate else statements when the result is already an object, which means it has already been created,
@@ -111,9 +126,19 @@ final readonly class MapMethodStatementsGenerator
             $statements = [...$statements, ...$addedDependenciesStatements];
         }
 
+        $mapStatement = new Stmt\Expression(new Expr\MethodCall(
+            new Expr\Variable('this'),
+            'doMap',
+            [
+                new Arg($variableRegistry->getSourceInput()),
+                new Arg($variableRegistry->getResult()),
+                new Arg($variableRegistry->getContext()),
+            ]
+        ));
+
         return [
             ...$statements,
-            ...$setterStatements,
+            $mapStatement,
             new Stmt\Return_($variableRegistry->getResult()),
         ];
     }

--- a/src/Generator/Shared/CachedReflectionStatementsGenerator.php
+++ b/src/Generator/Shared/CachedReflectionStatementsGenerator.php
@@ -93,8 +93,12 @@ final readonly class CachedReflectionStatementsGenerator
             return false;
         }
 
+        if ($metadata->mapperMetadata->lazyGhostClassName !== null) {
+            return true;
+        }
+
         $targetConstructor = $metadata->mapperMetadata->targetReflectionClass?->getConstructor();
 
-        return $targetConstructor && !$metadata->hasConstructor();
+        return $targetConstructor !== null;
     }
 }

--- a/src/Lazy/LazyCollection.php
+++ b/src/Lazy/LazyCollection.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Lazy;
+
+use AutoMapper\MapperInterface;
+
+/**
+ * @template S of object|array
+ * @template T of object|array
+ *
+ * @implements \Iterator<int|string, T>
+ *
+ * @phpstan-import-type MapperContextArray from \AutoMapper\MapperContext
+ */
+final class LazyCollection implements \Countable, \Iterator
+{
+    /** @var array<int|string, T|null> */
+    private array $buffer = [];
+
+    private bool $valid = true;
+
+    /**
+     * @param MapperInterface<S, T>   $mapper
+     * @param iterable<int|string, S> $sourceValues
+     * @param MapperContextArray      $context
+     */
+    public function __construct(
+        private readonly MapperInterface $mapper,
+        private iterable $sourceValues,
+        private array $context = [],
+    ) {
+    }
+
+    public function current(): mixed
+    {
+        /** @var T */
+        return current($this->buffer);
+    }
+
+    public function next(): void
+    {
+        if (false === next($this->buffer)) {
+            return;
+        }
+
+        // Get the next value from the source values
+        if (false !== next($this->sourceValues)) {
+            /** @var S $current */
+            $current = current($this->sourceValues);
+            /** @var int|string|null */
+            $key = key($this->sourceValues);
+
+            if (null !== $key) {
+                $this->buffer[$key] = $this->mapper->map($current, $this->context);
+            } else {
+                $this->buffer[] = $this->mapper->map($current, $this->context);
+            }
+
+            return;
+        }
+
+        $this->valid = false;
+    }
+
+    public function key(): mixed
+    {
+        /** @var int|string */
+        return key($this->buffer);
+    }
+
+    public function valid(): bool
+    {
+        return $this->valid;
+    }
+
+    public function rewind(): void
+    {
+        reset($this->buffer);
+    }
+
+    public function count(): int
+    {
+        if (\is_array($this->sourceValues)) {
+            return \count($this->sourceValues);
+        }
+
+        if ($this->sourceValues instanceof \Countable) {
+            return \count($this->sourceValues);
+        }
+
+        return iterator_count($this->sourceValues);
+    }
+}

--- a/src/Lazy/LazyMap.php
+++ b/src/Lazy/LazyMap.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Lazy;
+
+/**
+ * @implements \ArrayAccess<string, mixed>
+ * @implements \IteratorAggregate<string, mixed>
+ */
+final class LazyMap implements \ArrayAccess, \JsonSerializable, \IteratorAggregate
+{
+    /** @var array<mixed> */
+    private mixed $mappedValue = [];
+
+    private bool $initialized = false;
+
+    /**
+     * @param (callable(array<mixed>): mixed) $mapper
+     */
+    public function __construct(
+        private $mapper,
+    ) {
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        $this->initialize();
+
+        return isset($this->mappedValue[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        $this->initialize();
+
+        if (!isset($this->mappedValue[$offset])) {
+            return null;
+        }
+
+        return $this->mappedValue[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->initialize();
+
+        $this->mappedValue[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->initialize();
+
+        unset($this->mappedValue[$offset]);
+    }
+
+    private function initialize(): void
+    {
+        if ($this->initialized) {
+            return;
+        }
+
+        ($this->mapper)($this->mappedValue);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        $this->initialize();
+
+        return $this->mappedValue;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        $this->initialize();
+
+        return new \ArrayIterator($this->mappedValue);
+    }
+}

--- a/src/Loader/EvalLoader.php
+++ b/src/Loader/EvalLoader.php
@@ -10,6 +10,7 @@ use AutoMapper\Metadata\MetadataFactory;
 use AutoMapper\Metadata\MetadataRegistry;
 use PhpParser\PrettyPrinter\Standard;
 use PhpParser\PrettyPrinterAbstract;
+use Symfony\Component\VarExporter\ProxyHelper;
 
 /**
  * Use eval to load mappers.
@@ -31,6 +32,11 @@ final readonly class EvalLoader implements ClassLoaderInterface
 
     public function loadClass(MapperMetadata $mapperMetadata): void
     {
+        if ($mapperMetadata->targetReflectionClass !== null && $mapperMetadata->lazyGhostClassName !== null) {
+            $lazyGhostClass = 'class ' . $mapperMetadata->lazyGhostClassName . ProxyHelper::generateLazyGhost($mapperMetadata->targetReflectionClass);
+            eval($lazyGhostClass);
+        }
+
         eval($this->printer->prettyPrint($this->generator->generate(
             $this->metadataFactory->getGeneratorMetadata($mapperMetadata->source, $mapperMetadata->target)
         )));

--- a/src/MapperContext.php
+++ b/src/MapperContext.php
@@ -54,6 +54,7 @@ class MapperContext
     public const DATETIME_FORCE_TIMEZONE = 'datetime_force_timezone';
     public const MAP_TO_ACCESSOR_PARAMETER = 'map_to_accessor_parameter';
     public const NORMALIZER_FORMAT = 'normalizer_format';
+    public const LAZY_MAPPING = 'lazy_mapping';
 
     /** @var MapperContextArray */
     private array $context = [
@@ -329,5 +330,13 @@ class MapperContext
         } catch (\Exception $e) {
             throw new InvalidArgumentException("Invalid timezone \"$timezone\" passed to automapper context.", previous: $e);
         }
+    }
+
+    /**
+     * @param array{lazy_mapping?: bool} $context
+     */
+    public static function shouldLazyLoad(array $context): bool
+    {
+        return $context[self::LAZY_MAPPING] ?? false;
     }
 }

--- a/src/Metadata/MapperMetadata.php
+++ b/src/Metadata/MapperMetadata.php
@@ -10,6 +10,7 @@ class MapperMetadata
 {
     /** @var class-string<object> */
     public string $className;
+    public ?string $lazyGhostClassName;
 
     /** @var \ReflectionClass<object>|null */
     public readonly ?\ReflectionClass $sourceReflectionClass;
@@ -45,6 +46,12 @@ class MapperMetadata
         /** @var class-string<object> $className */
         $className = sprintf('%s%s_%s', $this->classPrefix, str_replace('\\', '_', $this->source), str_replace('\\', '_', $this->target));
         $this->className = $className;
+
+        if (null !== $this->targetReflectionClass && !$this->targetReflectionClass->isFinal() && !$this->targetReflectionClass->isAbstract() && !$this->targetReflectionClass->isReadOnly()) {
+            $this->lazyGhostClassName = sprintf('%s%s_%s_LazyGhost', $this->classPrefix, str_replace('\\', '_', $this->source), str_replace('\\', '_', $this->target));
+        } else {
+            $this->lazyGhostClassName = null;
+        }
     }
 
     public function getHash(): string

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -68,6 +68,7 @@ use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
@@ -100,6 +101,46 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertIsArray($userDto->money);
         self::assertCount(1, $userDto->money);
         self::assertSame(20.10, $userDto->money[0]);
+    }
+
+    public function testAutoMappingLazy(): void
+    {
+        $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true);
+
+        $address = new Address();
+        $address->setCity('Toulon');
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $user->address = $address;
+        $user->addresses[] = $address;
+        $user->money = 20.10;
+
+        /** @var Fixtures\UserDTO&LazyObjectInterface $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class, [MapperContext::LAZY_MAPPING => true]);
+
+        self::assertNotSame(Fixtures\UserDTO::class, $userDto::class);
+        self::assertInstanceOf(LazyObjectInterface::class, $userDto);
+        self::assertFalse($userDto->isLazyObjectInitialized());
+
+        self::assertInstanceOf(Fixtures\UserDTO::class, $userDto);
+
+        self::assertSame(1, $userDto->id);
+        self::assertSame('yolo', $userDto->getName());
+        self::assertSame(13, $userDto->age);
+        self::assertCount(1, $userDto->addresses);
+
+        // Sub object are also lazy loaded
+        self::assertNotSame(AddressDTO::class, $userDto->address::class);
+        self::assertInstanceOf(LazyObjectInterface::class, $userDto->address);
+        self::assertFalse($userDto->address->isLazyObjectInitialized());
+
+        self::assertInstanceOf(AddressDTO::class, $userDto->address);
+        self::assertInstanceOf(AddressDTO::class, $userDto->addresses[0]);
+        self::assertSame('Toulon', $userDto->address->city);
+        self::assertSame('Toulon', $userDto->addresses[0]->city);
+        self::assertIsArray($userDto->money);
+        self::assertCount(1, $userDto->money);
+        self::assertSame(20.10, $userDto->money[0]);
+        self::assertTrue($userDto->isLazyObjectInitialized());
     }
 
     public function testAutoMapperFromArray(): void
@@ -159,6 +200,22 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertIsArray($userData);
         self::assertEquals(1, $userData['id']);
         self::assertIsArray($userData['address']);
+        self::assertIsString($userData['createdAt']);
+    }
+
+    public function testAutoMapperToArrayLazy(): void
+    {
+        $address = new Address();
+        $address->setCity('Toulon');
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $user->address = $address;
+        $user->addresses[] = $address;
+
+        $userData = $this->autoMapper->map($user, 'array', [MapperContext::LAZY_MAPPING => true]);
+
+        self::assertInstanceOf(\ArrayAccess::class, $userData);
+        self::assertEquals(1, $userData['id']);
+        self::assertInstanceOf(\ArrayAccess::class, $userData['address']);
         self::assertIsString($userData['createdAt']);
     }
 


### PR DESCRIPTION
This introduce the possibility to do lazy mapping

The following call : 

```php
$userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class, [MapperContext::LAZY_MAPPING => true]);
```

Will produce a lazy ghost object for userDto which will only be mapped when calling one of its value
Nested objects are also lazy loaded

This will allow to map large complex tree instantly and only map values when it's needed, this may decreses performance in most cases so it's not enabled by default, but in some cases where only a part of a data is needed this may be useful and save process / memory

This also opens the door to json streaming (will need a special LazyArray object but it's totally doable)