### PR TITLE
fix(metadata): fix generating discriminator dependencies

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -156,10 +156,13 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
         $customTransformerRegistry = new PropertyTransformerRegistry($propertyTransformers);
         $metadataRegistry = new MetadataRegistry($configuration);
         $providerRegistry = new ProviderRegistry($providers);
+        $classDiscriminatorResolver = new ClassDiscriminatorResolver($classDiscriminatorFromClassMetadata);
+
         $metadataFactory = MetadataFactory::create(
             $configuration,
             $customTransformerRegistry,
             $metadataRegistry,
+            $classDiscriminatorResolver,
             $transformerFactories,
             $classMetadataFactory,
             $nameConverter,
@@ -168,7 +171,7 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
         );
 
         $mapperGenerator = new MapperGenerator(
-            new ClassDiscriminatorResolver($classDiscriminatorFromClassMetadata),
+            $classDiscriminatorResolver,
             $configuration,
             $expressionLanguage,
         );

--- a/src/Generator/InjectMapperMethodStatementsGenerator.php
+++ b/src/Generator/InjectMapperMethodStatementsGenerator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AutoMapper\Generator;
 
-use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
 use AutoMapper\Metadata\Dependency;
 use AutoMapper\Metadata\GeneratorMetadata;
 use PhpParser\Node\Arg;
@@ -29,10 +28,8 @@ use PhpParser\Node\Stmt;
  */
 final readonly class InjectMapperMethodStatementsGenerator
 {
-    public function __construct(
-        private DiscriminatorStatementsGenerator $discriminatorStatementsGeneratorSource,
-        private DiscriminatorStatementsGenerator $discriminatorStatementsGeneratorTarget,
-    ) {
+    public function __construct()
+    {
     }
 
     /**
@@ -66,8 +63,6 @@ final readonly class InjectMapperMethodStatementsGenerator
 
         return [
             ...$injectMapperStatements,
-            ...$this->discriminatorStatementsGeneratorSource->injectMapperStatements($metadata),
-            ...$this->discriminatorStatementsGeneratorTarget->injectMapperStatements($metadata),
         ];
     }
 }

--- a/src/Generator/MapperGenerator.php
+++ b/src/Generator/MapperGenerator.php
@@ -44,17 +44,14 @@ final readonly class MapperGenerator
         );
 
         $this->mapMethodStatementsGenerator = new MapMethodStatementsGenerator(
-            $discriminatorStatementsGeneratorSource = new DiscriminatorStatementsGenerator($classDiscriminatorResolver, true),
-            $discriminatorStatementsGeneratorTarget = new DiscriminatorStatementsGenerator($classDiscriminatorResolver, false),
+            new DiscriminatorStatementsGenerator($classDiscriminatorResolver, true),
+            new DiscriminatorStatementsGenerator($classDiscriminatorResolver, false),
             $cachedReflectionStatementsGenerator,
             $expressionLanguage,
             $configuration->allowReadOnlyTargetToPopulate,
         );
 
-        $this->injectMapperMethodStatementsGenerator = new InjectMapperMethodStatementsGenerator(
-            $discriminatorStatementsGeneratorSource,
-            $discriminatorStatementsGeneratorTarget
-        );
+        $this->injectMapperMethodStatementsGenerator = new InjectMapperMethodStatementsGenerator();
 
         $this->disableGeneratedMapper = !$configuration->autoRegister;
     }

--- a/src/Generator/Shared/ClassDiscriminatorResolver.php
+++ b/src/Generator/Shared/ClassDiscriminatorResolver.php
@@ -50,7 +50,7 @@ final readonly class ClassDiscriminatorResolver
     }
 
     /**
-     * @return array<string, string>
+     * @return array<class-string<object>, string>
      */
     public function discriminatorMapperNames(GeneratorMetadata $metadata, bool $fromSource): array
     {

--- a/src/Generator/Shared/DiscriminatorStatementsGenerator.php
+++ b/src/Generator/Shared/DiscriminatorStatementsGenerator.php
@@ -29,46 +29,6 @@ final readonly class DiscriminatorStatementsGenerator
 
     /**
      * @return list<Stmt>
-     */
-    public function injectMapperStatements(GeneratorMetadata $metadata): array
-    {
-        if (!$this->supports($metadata)) {
-            return [];
-        }
-
-        $discriminatorMapperNames = $this->classDiscriminatorResolver->discriminatorMapperNames($metadata, $this->fromSource);
-
-        $injectMapperStatements = [];
-
-        foreach ($discriminatorMapperNames as $typeTarget => $discriminatorMapperName) {
-            /*
-             * We inject dependencies for all the discriminator variant
-             *
-             * ```php
-             *  $this->mappers['Discriminator_Mapper_VariantA'] = $autoMapperRegistry->getMapper($source, VariantA::class);
-             *  $this->mappers['Discriminator_Mapper_VariantB'] = $autoMapperRegistry->getMapper($source, VariantB::class);
-             *  ...
-             * ```
-             */
-            $injectMapperStatements[] = new Stmt\Expression(
-                new Expr\Assign(
-                    new Expr\ArrayDimFetch(
-                        new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'),
-                        new Scalar\String_($discriminatorMapperName)
-                    ),
-                    new Expr\MethodCall(new Expr\Variable('autoMapperRegistry'), 'getMapper', [
-                        new Arg(new Scalar\String_($this->fromSource ? $typeTarget : $metadata->mapperMetadata->source)),
-                        new Arg(new Scalar\String_($this->fromSource ? $metadata->mapperMetadata->target : $typeTarget)),
-                    ])
-                )
-            );
-        }
-
-        return $injectMapperStatements;
-    }
-
-    /**
-     * @return list<Stmt>
      *
      * We return the object created with the correct mapper depending on the variant, this will skip the next mapping phase in this situation
      *

--- a/src/Symfony/Bundle/Resources/config/metadata.php
+++ b/src/Symfony/Bundle/Resources/config/metadata.php
@@ -8,6 +8,7 @@ use AutoMapper\Configuration;
 use AutoMapper\Extractor\FromSourceMappingExtractor;
 use AutoMapper\Extractor\FromTargetMappingExtractor;
 use AutoMapper\Extractor\SourceTargetMappingExtractor;
+use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
 use AutoMapper\Metadata\MetadataFactory;
 use AutoMapper\Transformer\TransformerFactoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -47,6 +48,7 @@ return static function (ContainerConfigurator $container) {
                 service(TransformerFactoryInterface::class),
                 service(EventDispatcherInterface::class),
                 service('automapper.config_mapping_registry'),
+                service(ClassDiscriminatorResolver::class),
             ])
     ;
 };

--- a/src/Transformer/MapperDependency.php
+++ b/src/Transformer/MapperDependency.php
@@ -14,8 +14,8 @@ namespace AutoMapper\Transformer;
 final readonly class MapperDependency
 {
     /**
-     * @param class-string $source
-     * @param class-string $target
+     * @param class-string<object>|'array' $source
+     * @param class-string<object>|'array' $target
      */
     public function __construct(
         public string $name,

--- a/src/Transformer/ObjectTransformer.php
+++ b/src/Transformer/ObjectTransformer.php
@@ -95,7 +95,7 @@ final readonly class ObjectTransformer implements TransformerInterface, Dependen
     }
 
     /**
-     * @return class-string<mixed>|'array'
+     * @return class-string<object>|'array'
      */
     private function getSource(): string
     {
@@ -105,7 +105,7 @@ final readonly class ObjectTransformer implements TransformerInterface, Dependen
             /**
              * Cannot be null since we check the source type is an Object.
              *
-             * @var class-string<mixed> $sourceTypeName
+             * @var class-string<object> $sourceTypeName
              */
             $sourceTypeName = $this->sourceType->getClassName();
         }
@@ -114,7 +114,7 @@ final readonly class ObjectTransformer implements TransformerInterface, Dependen
     }
 
     /**
-     * @return class-string<mixed>|'array'
+     * @return class-string<object>|'array'
      */
     private function getTarget(): string
     {
@@ -124,7 +124,7 @@ final readonly class ObjectTransformer implements TransformerInterface, Dependen
             /**
              * Cannot be null since we check the target type is an Object.
              *
-             * @var class-string<mixed> $targetTypeName
+             * @var class-string<object> $targetTypeName
              */
             $targetTypeName = $this->targetType->getClassName();
         }

--- a/tests/Bundle/Resources/App/Api/Processor/BookProcessor.php
+++ b/tests/Bundle/Resources/App/Api/Processor/BookProcessor.php
@@ -14,11 +14,13 @@ final readonly class BookProcessor implements ProcessorInterface
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = [])
     {
         if (!$data instanceof Book) {
-            return;
+            return null;
         }
 
         if ($operation instanceof HttpOperation && $operation->getMethod() === 'POST') {
             $data->id = random_int(1, 1000);
         }
+
+        return $data;
     }
 }

--- a/tests/Bundle/Resources/config/packages/automapper.yaml
+++ b/tests/Bundle/Resources/config/packages/automapper.yaml
@@ -13,6 +13,7 @@ automapper:
     mappers:
       - { source: 'AutoMapper\Tests\Bundle\Resources\App\Entity\NestedObject', target: 'array' }
       - { source: 'AutoMapper\Tests\Bundle\Resources\App\Entity\AddressDTO', target: 'array', reverse: true }
+      - { source: 'AutoMapper\Tests\Bundle\Resources\App\Entity\Pet', target: 'array', reverse: true }
       - { source: 'AutoMapper\Tests\Bundle\Resources\App\Entity\UserDTO', target: 'array', reverse: false }
       - { source: 'array', target: 'AutoMapper\Tests\Bundle\Resources\App\Entity\Order', reverse: false }
       - { source: 'AutoMapper\Tests\Bundle\Resources\App\Api\Entity\Book', target: 'array', reverse: true }

--- a/tests/Bundle/ServiceInstantiationTest.php
+++ b/tests/Bundle/ServiceInstantiationTest.php
@@ -44,6 +44,9 @@ class ServiceInstantiationTest extends WebTestCase
         self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Tests_Bundle_Resources_App_Entity_NestedObject_array.php');
         self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Tests_Bundle_Resources_App_Entity_User_array.php');
         self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Tests_Bundle_Resources_App_Entity_AddressDTO_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Tests_Bundle_Resources_App_Entity_Pet_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Tests_Bundle_Resources_App_Entity_Dog_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_AutoMapper_Tests_Bundle_Resources_App_Entity_Cat_array.php');
     }
 
     public function testAutoMapper(): void

--- a/tests/Metadata/MetadataFactoryTest.php
+++ b/tests/Metadata/MetadataFactoryTest.php
@@ -8,6 +8,7 @@ use AutoMapper\Configuration;
 use AutoMapper\Extractor\FromSourceMappingExtractor;
 use AutoMapper\Extractor\FromTargetMappingExtractor;
 use AutoMapper\Extractor\SourceTargetMappingExtractor;
+use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
 use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\MetadataFactory;
 use AutoMapper\Metadata\MetadataRegistry;
@@ -88,7 +89,8 @@ class MetadataFactoryTest extends AutoMapperBaseTest
             $fromTargetMappingExtractor,
             $transformerFactory,
             new EventDispatcher(),
-            new MetadataRegistry($configuration)
+            new MetadataRegistry($configuration),
+            new ClassDiscriminatorResolver()
         );
     }
 


### PR DESCRIPTION
This fix a bug where when registering a class that have discriminator mapping it's sub classes would not be registered and created during warmup