### PR TITLE
feat(exceptions): better exception naming, add interface to group all exceptions

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper;
 
-use AutoMapper\Exception\NoMappingFoundException;
+use AutoMapper\Exception\InvalidMappingException;
 use AutoMapper\Generator\MapperGenerator;
 use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
 use AutoMapper\Loader\ClassLoaderInterface;
@@ -109,7 +109,7 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
         }
 
         if ('array' === $sourceType && 'array' === $targetType) {
-            throw new NoMappingFoundException('Cannot map this value, both source and target are array.');
+            throw new InvalidMappingException('Cannot map this value, both source and target are array.');
         }
 
         return $this->getMapper($sourceType, $targetType)->map($source, $context);

--- a/src/Exception/AutoMapperException.php
+++ b/src/Exception/AutoMapperException.php
@@ -7,6 +7,6 @@ namespace AutoMapper\Exception;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class NoMappingFoundException extends RuntimeException
+interface AutoMapperException
 {
 }

--- a/src/Exception/BadMapDefinitionException.php
+++ b/src/Exception/BadMapDefinitionException.php
@@ -7,6 +7,6 @@ namespace AutoMapper\Exception;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class BadMapDefinitionException extends RuntimeException
+final class BadMapDefinitionException extends MetadataException
 {
 }

--- a/src/Exception/CompileException.php
+++ b/src/Exception/CompileException.php
@@ -7,6 +7,6 @@ namespace AutoMapper\Exception;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class CompileException extends RuntimeException
+final class CompileException extends \LogicException implements AutoMapperException
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -7,6 +7,6 @@ namespace AutoMapper\Exception;
 /**
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-final class InvalidArgumentException extends \InvalidArgumentException
+final class InvalidArgumentException extends \InvalidArgumentException implements AutoMapperException
 {
 }

--- a/src/Exception/InvalidMappingException.php
+++ b/src/Exception/InvalidMappingException.php
@@ -7,6 +7,6 @@ namespace AutoMapper\Exception;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class InvalidMappingException extends RuntimeException
+final class InvalidMappingException extends MetadataException
 {
 }

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -7,6 +7,6 @@ namespace AutoMapper\Exception;
 /**
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-final class LogicException extends \LogicException
+final class LogicException extends \LogicException implements AutoMapperException
 {
 }

--- a/src/Exception/MetadataException.php
+++ b/src/Exception/MetadataException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Exception;
+
+class MetadataException extends \RuntimeException implements AutoMapperException
+{
+}

--- a/src/Exception/MissingConstructorArgumentsException.php
+++ b/src/Exception/MissingConstructorArgumentsException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Exception;
 
-final class MissingConstructorArgumentsException extends \RuntimeException
+final class MissingConstructorArgumentsException extends RuntimeException
 {
     /**
      * @param string[]          $missingArguments

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace AutoMapper\Exception;
 
-/**
- * @author Joel Wurtz <jwurtz@jolicode.com>
- */
-class RuntimeException extends \RuntimeException
+class RuntimeException extends \RuntimeException implements AutoMapperException
 {
 }

--- a/src/Extractor/ReadAccessor.php
+++ b/src/Extractor/ReadAccessor.php
@@ -62,7 +62,7 @@ final class ReadAccessor
                 /*
                  * Create method call argument to read value from context and throw exception if not found
                  *
-                 * $context['map_to_accessor_parameter']['some_key'] ?? throw new \InvalidArgumentException('error message');
+                 * $context['map_to_accessor_parameter']['some_key'] ?? throw new InvalidArgumentException('error message');
                  */
                 $methodCallArguments[] = new Arg(
                     new Expr\BinaryOp\Coalesce(
@@ -75,7 +75,7 @@ final class ReadAccessor
                         ),
                         new Expr\Throw_(
                             new Expr\New_(
-                                new Name\FullyQualified(\InvalidArgumentException::class),
+                                new Name\FullyQualified(InvalidArgumentException::class),
                                 [
                                     new Arg(
                                         new Scalar\String_(

--- a/src/Generator/CreateTargetStatementsGenerator.php
+++ b/src/Generator/CreateTargetStatementsGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Generator;
 
-use AutoMapper\Exception\LogicException;
+use AutoMapper\Exception\CompileException;
 use AutoMapper\Exception\MissingConstructorArgumentsException;
 use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
 use AutoMapper\Generator\Shared\DiscriminatorStatementsGenerator;
@@ -323,6 +323,6 @@ final readonly class CreateTargetStatementsGenerator
             return $expr->expr;
         }
 
-        throw new LogicException('Cannot extract expr from ' . var_export($value, true));
+        throw new CompileException('Cannot extract expr from ' . var_export($value, true));
     }
 }

--- a/src/Generator/MapperGenerator.php
+++ b/src/Generator/MapperGenerator.php
@@ -7,7 +7,7 @@ namespace AutoMapper\Generator;
 use AutoMapper\AutoMapperRegistryInterface;
 use AutoMapper\Configuration;
 use AutoMapper\Exception\CompileException;
-use AutoMapper\Exception\NoMappingFoundException;
+use AutoMapper\Exception\InvalidMappingException;
 use AutoMapper\GeneratedMapper;
 use AutoMapper\Generator\Shared\CachedReflectionStatementsGenerator;
 use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
@@ -59,12 +59,12 @@ final readonly class MapperGenerator
      * Generate Class AST given metadata for a mapper.
      *
      * @throws CompileException
-     * @throws NoMappingFoundException
+     * @throws InvalidMappingException
      */
     public function generate(GeneratorMetadata $metadata): Stmt\Class_
     {
         if ($this->disableGeneratedMapper) {
-            throw new NoMappingFoundException('No mapper found for source ' . $metadata->mapperMetadata->source . ' and target ' . $metadata->mapperMetadata->target);
+            throw new InvalidMappingException('No mapper found for source ' . $metadata->mapperMetadata->source . ' and target ' . $metadata->mapperMetadata->target);
         }
 
         return (new Builder\Class_($metadata->mapperMetadata->className))

--- a/src/Generator/PropertyConditionsGenerator.php
+++ b/src/Generator/PropertyConditionsGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Generator;
 
-use AutoMapper\Exception\LogicException;
+use AutoMapper\Exception\CompileException;
 use AutoMapper\MapperContext;
 use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\PropertyMetadata;
@@ -259,7 +259,7 @@ final readonly class PropertyConditionsGenerator
                 }
 
                 if ($argumentsCount > 2) {
-                    throw new LogicException('Callable condition must have 1 or 2 arguments required, but it has ' . $argumentsCount);
+                    throw new CompileException('Callable condition must have 1 or 2 arguments required, but it has ' . $argumentsCount);
                 }
             }
 
@@ -303,6 +303,6 @@ final readonly class PropertyConditionsGenerator
             return $expr->expr;
         }
 
-        throw new LogicException('Cannot use callback or create expression language condition from expression "' . $propertyMetadata->if . "'");
+        throw new CompileException('Cannot use callback or create expression language condition from expression "' . $propertyMetadata->if . "'");
     }
 }

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Loader;
 
-use AutoMapper\Exception\RuntimeException;
+use AutoMapper\Exception\CompileException;
 use AutoMapper\Generator\MapperGenerator;
 use AutoMapper\Metadata\MapperMetadata;
 use AutoMapper\Metadata\MetadataFactory;
@@ -129,7 +129,7 @@ final class FileLoader implements ClassLoaderInterface
         $fp = fopen($file, 'w');
 
         if (false === $fp) {
-            throw new RuntimeException(sprintf('Could not open file "%s"', $file));
+            throw new CompileException(sprintf('Could not open file "%s"', $file));
         }
 
         if (flock($fp, LOCK_EX)) {

--- a/src/MapperContext.php
+++ b/src/MapperContext.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper;
 
 use AutoMapper\Exception\CircularReferenceException;
-use AutoMapper\Exception\RuntimeException;
+use AutoMapper\Exception\InvalidArgumentException;
 
 /**
  * Context for mapping.
@@ -327,7 +327,7 @@ class MapperContext
         try {
             return new \DateTimeZone($timezone);
         } catch (\Exception $e) {
-            throw new RuntimeException("Invalid timezone \"$timezone\" passed to automapper context.", previous: $e);
+            throw new InvalidArgumentException("Invalid timezone \"$timezone\" passed to automapper context.", previous: $e);
         }
     }
 }

--- a/src/Transformer/ExpressionLanguageTransformer.php
+++ b/src/Transformer/ExpressionLanguageTransformer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\Exception\LogicException;
+use AutoMapper\Exception\CompileException;
 use AutoMapper\Generator\UniqueVariableScope;
 use AutoMapper\Metadata\PropertyMetadata;
 use PhpParser\Node\Expr;
@@ -34,6 +34,6 @@ final readonly class ExpressionLanguageTransformer implements TransformerInterfa
             return [$expr->expr, []];
         }
 
-        throw new LogicException('Cannot use callback or create expression language condition from expression "' . $this->expression . "'");
+        throw new CompileException('Cannot use callback or create expression language condition from expression "' . $this->expression . "'");
     }
 }

--- a/src/Transformer/FixedValueTransformer.php
+++ b/src/Transformer/FixedValueTransformer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
-use AutoMapper\Exception\LogicException;
+use AutoMapper\Exception\CompileException;
 use AutoMapper\Generator\UniqueVariableScope;
 use AutoMapper\Metadata\PropertyMetadata;
 use PhpParser\Node\Expr;
@@ -34,6 +34,6 @@ final readonly class FixedValueTransformer implements TransformerInterface, Allo
             return [$expr->expr, []];
         }
 
-        throw new LogicException('Cannot create php code from value ' . json_encode($this->value));
+        throw new CompileException('Cannot create php code from value ' . json_encode($this->value));
     }
 }

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -9,8 +9,8 @@ use AutoMapper\Configuration;
 use AutoMapper\ConstructorStrategy;
 use AutoMapper\Event\PropertyMetadataEvent;
 use AutoMapper\Exception\CircularReferenceException;
+use AutoMapper\Exception\InvalidMappingException;
 use AutoMapper\Exception\MissingConstructorArgumentsException;
-use AutoMapper\Exception\NoMappingFoundException;
 use AutoMapper\Exception\ReadOnlyTargetException;
 use AutoMapper\MapperContext;
 use AutoMapper\Provider\EarlyReturn;
@@ -769,7 +769,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testInvalidMappingBothArray(): void
     {
-        self::expectException(NoMappingFoundException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $data = ['test' => 'foo'];
         $array = $this->autoMapper->map($data, 'array');
@@ -777,7 +777,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     public function testNoAutoRegister(): void
     {
-        self::expectException(NoMappingFoundException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $automapper = AutoMapper::create(new Configuration(autoRegister: false, classPrefix: 'NoAutoRegister_'));
         $automapper->getMapper(Fixtures\User::class, Fixtures\UserDTO::class);

--- a/tests/MapperContextTest.php
+++ b/tests/MapperContextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AutoMapper\Tests;
 
 use AutoMapper\Exception\CircularReferenceException;
+use AutoMapper\Exception\InvalidArgumentException;
 use AutoMapper\MapperContext;
 use PHPUnit\Framework\TestCase;
 
@@ -159,7 +160,7 @@ class MapperContextTest extends TestCase
 
     public function testItThrowsExceptionWithInvalidTimeZone(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid timezone "foo" passed to automapper context.');
 
         MapperContext::getForcedTimezone([MapperContext::DATETIME_FORCE_TIMEZONE => 'foo']);


### PR DESCRIPTION
This implement the following pattern : 

 * All exceptions throw by the lib implement the `AutoMapperException` interface
 * Split exceptions in 3 categories : 
   * MetadataException : happens when loading metadata
   * CompileException : happens when generating code
   * RuntimeException : happens when executing the mapping