### PR TITLE
fix(bundle): use map_private_properties when configuring ReflectionExtractor

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
@@ -67,6 +67,8 @@ class AutoMapperExtension extends Extension
             ->setArgument('$allowReadOnlyTargetToPopulate', $config['allow_readonly_target_to_populate'])
         ;
 
+        $container->setParameter('automapper.map_private_properties', $config['map_private_properties']);
+
         $container->registerForAutoconfiguration(PropertyTransformerInterface::class)->addTag('automapper.property_transformer');
 
         if ($config['loader']['eval']) {

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -22,6 +22,12 @@ class PropertyInfoPass implements CompilerPassInterface
             return;
         }
 
+        $flags = ReflectionExtractor::ALLOW_PUBLIC;
+
+        if ($container->getParameter('automapper.map_private_properties')) {
+            $flags |= ReflectionExtractor::ALLOW_PRIVATE | ReflectionExtractor::ALLOW_PROTECTED;
+        }
+
         $container->setDefinition(
             'automapper.property_info.reflection_extractor',
             new Definition(
@@ -31,7 +37,7 @@ class PropertyInfoPass implements CompilerPassInterface
                     '$accessorPrefixes' => null,
                     '$arrayMutatorPrefixes' => null,
                     '$enableConstructorExtraction' => true,
-                    '$accessFlags' => ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE,
+                    '$accessFlags' => $flags,
                 ]
             )
         );

--- a/tests/Bundle/Resources/App/AppKernel.php
+++ b/tests/Bundle/Resources/App/AppKernel.php
@@ -5,14 +5,39 @@ declare(strict_types=1);
 namespace AutoMapper\Tests\Bundle\Resources\App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
     use MicroKernelTrait;
 
+    public function __construct(
+        string $environment,
+        bool $debug,
+        private ?string $additionalConfigFile = null
+    ) {
+        parent::__construct($environment, $debug);
+    }
+
+    protected function buildContainer(): ContainerBuilder
+    {
+        $containerBuilder = parent::buildContainer();
+
+        if ($this->additionalConfigFile) {
+            $this->getContainerLoader($containerBuilder)->load($this->additionalConfigFile);
+        }
+
+        return $containerBuilder;
+    }
+
     public function getProjectDir(): string
     {
         return __DIR__ . '/..';
+    }
+
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir() . '/' . md5($this->additionalConfigFile ?? '');
     }
 }

--- a/tests/Bundle/Resources/config/with-private-properties.yml
+++ b/tests/Bundle/Resources/config/with-private-properties.yml
@@ -1,0 +1,3 @@
+automapper:
+    class_prefix: "Symfony_Mapper_With_Private_Property"
+    map_private_properties: true


### PR DESCRIPTION
configuration `map_private_properties` was not used to configure service `automapper.property_info.reflection_extractor` whereas without the bundle, `\AutoMapper\Configuration::$mapPrivateProperties` is actually used, this PR fixes this.

I had to introduce a way to have several configurations available for the fixture bundle, I'm using `KernelTestCase::createKernel()` + an additional config file path for this.

waiting for https://github.com/jolicode/automapper/pull/137