### PR TITLE
Make ClassDiscriminatorResolver optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - [GH#131](https://github.com/jolicode/automapper/pull/131) Require mandatory packages
+- [GH#132](https://github.com/jolicode/automapper/pull/132) Use DI Extension class instead of deprecated HttpKernel Extension
+- [GH#130](https://github.com/jolicode/automapper/pull/130) Make ClassDiscriminatorResolver optional
 
 ## [9.0.1] - 2024-05-10
 ### Fixes

--- a/src/Symfony/Bundle/Resources/config/event_serializer.php
+++ b/src/Symfony/Bundle/Resources/config/event_serializer.php
@@ -8,6 +8,8 @@ use AutoMapper\Event\PropertyMetadataEvent;
 use AutoMapper\EventListener\Symfony\SerializerGroupListener;
 use AutoMapper\EventListener\Symfony\SerializerIgnoreListener;
 use AutoMapper\EventListener\Symfony\SerializerMaxDepthListener;
+use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -22,5 +24,11 @@ return static function (ContainerConfigurator $container) {
         ->set(SerializerIgnoreListener::class)
             ->args([service('serializer.mapping.class_metadata_factory')])
             ->tag('kernel.event_listener', ['event' => PropertyMetadataEvent::class, 'priority' => -64])
+
+        ->set(ClassDiscriminatorResolver::class)
+            ->args([service('automapper.mapping.class_discriminator_from_class_metadata')])
+
+        ->set('automapper.mapping.class_discriminator_from_class_metadata', ClassDiscriminatorFromClassMetadata::class)
+            ->args([service('serializer.mapping.class_metadata_factory')])
     ;
 };

--- a/src/Symfony/Bundle/Resources/config/generator.php
+++ b/src/Symfony/Bundle/Resources/config/generator.php
@@ -7,7 +7,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use AutoMapper\Configuration;
 use AutoMapper\Generator\MapperGenerator;
 use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
-use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -19,9 +18,6 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set(ClassDiscriminatorResolver::class)
-            ->args([service('automapper.mapping.class_discriminator_from_class_metadata')])
-
-        ->set('automapper.mapping.class_discriminator_from_class_metadata', ClassDiscriminatorFromClassMetadata::class)
-            ->args([service('serializer.mapping.class_metadata_factory')])
+            ->args([null])
     ;
 };


### PR DESCRIPTION
`symfony/serializer` should not be required when installing AutoMapper, so with this PR I make the `ClassDiscriminatorResolver` optional within the bundle so we can install it without the Serializer installed.

Will fix a part of #127, but not everything.