### PR TITLE
Require mandatory packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- [GH#131](https://github.com/jolicode/automapper/pull/131) Require mandatory packages
+
 ## [9.0.1] - 2024-05-10
 ### Fixes
 - [GH#124](https://github.com/jolicode/automapper/pull/124) Fix Symfony's WebProfiler issues

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,18 @@
     "require": {
         "php": "^8.2",
         "nikic/php-parser": "^4.18 || ^5.0",
+        "symfony/deprecation-contracts": "^3.0",
         "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/expression-language": "^6.4 || ^7.0",
-        "symfony/deprecation-contracts": "^3.0",
-        "symfony/property-info": "^6.4 || ^7.0"
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "phpdocumentor/type-resolver": "^1.7"
     },
     "require-dev": {
         "api-platform/core": "^3.0.4",
         "doctrine/annotations": "~1.0",
         "doctrine/inflector": "^2.0",
         "moneyphp/money": "^3.3.2",
-        "phpdocumentor/type-resolver": "^1.7",
         "phpunit/phpunit": "^9.0",
         "symfony/browser-kit": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
@@ -36,7 +37,6 @@
         "symfony/framework-bundle": "*",
         "symfony/http-client": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",
-        "symfony/property-access": "^6.4 || ^7.0",
         "symfony/serializer": "*",
         "symfony/stopwatch": "^6.4 || ^7.0",
         "symfony/twig-bundle": "^6.4 || ^7.0",


### PR DESCRIPTION
Because they are required to make AutoMapper works, no reason not to put them.

Will fix a part of https://github.com/jolicode/automapper/issues/127, but not everything.