### PR TITLE
Remove useless condition in `MapperMetadata`

### DIFF
--- a/src/Metadata/MapperMetadata.php
+++ b/src/Metadata/MapperMetadata.php
@@ -30,7 +30,7 @@ class MapperMetadata
         public bool $registered,
         private string $classPrefix = 'Mapper_',
     ) {
-        if (class_exists($this->source) && !\in_array($this->source, ['array', \stdClass::class], true)) {
+        if (class_exists($this->source) && $this->source !== \stdClass::class) {
             $reflectionSource = new \ReflectionClass($this->source);
             $this->sourceReflectionClass = $reflectionSource;
         } else {


### PR DESCRIPTION
If `$this->source` is a class, it cannot be `array`. This is the same condition for `$this->target` just below.

Introduced by https://github.com/jolicode/automapper/commit/d8c708d3a199a9f5e02c2a5075a539219a9fc978#diff-4c1e0a70928058f8c9f0eb96b64ef30126ebaef5dfc1567f78dea8804c4b0f2cR28