### PR TITLE
Make MapperMetadata non-internal because it is used within PropertyTransformerSupportInterface interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GH#135](https://github.com/jolicode/automapper/pull/135) Fix return type of AutoMapper::create()
 - [GH#139](https://github.com/jolicode/automapper/pull/139) Fix unreachable variable in BuitinTransformer
 - [GH#138](https://github.com/jolicode/automapper/pull/138) Declare CopyTransformerFactory as a service
+- [GH#142](https://github.com/jolicode/automapper/pull/142) Make MapperMetadata non-internal because it is used within PropertyTransformerSupportInterface interface
 
 ## [9.0.1] - 2024-05-10
 ### Fixed

--- a/src/Metadata/MapperMetadata.php
+++ b/src/Metadata/MapperMetadata.php
@@ -6,9 +6,6 @@ namespace AutoMapper\Metadata;
 
 use AutoMapper\AutoMapper;
 
-/**
- * @internal
- */
 class MapperMetadata
 {
     /** @var class-string<object> */


### PR DESCRIPTION
Fixes #134 