### PR TITLE
fix(doc): typing error in Configuration for Symfony

### DIFF
--- a/docs/bundle/configuration.md
+++ b/docs/bundle/configuration.md
@@ -26,7 +26,7 @@ automapper:
   serializer_attributes: true
   api_platform: false
   name_converter: null
-  mappings:
+  mapping:
     paths:
       - "%kernel.project_dir%/src/Entity"
     mappers:
@@ -74,7 +74,7 @@ indicate if we use the attribute of the symfony/serializer during the mapping, t
 inject extra data (json ld) in the mappers when we map a Resource class to or from an array.
 * `name_converter` (default: `null`): A service id which implement the `AdvancedNameConverterInterface` from the symfony/serializer,
   this name converter will be used when mapping from an array to an object and vice versa;
-* `mappings`: Allow to auto register the mappers for warmup, and selecting them to normalizer if wanted
+* `mapping`: Allow to auto register the mappers for warmup, and selecting them to normalizer if wanted
     * `paths`: A list of paths where to look for mappers to register; This will automatically register all classes
       with the `#[Mapper]` attribute in the given paths.
     * `mappers`: A list of mapping to register, each mapping should have a `source` and a `target` key, and can have


### PR DESCRIPTION
Fixing little mistake in Symfony bundle configuration documentation.

Bundle await for `mapping` but documentation show `mappings`