### PR TITLE
fix(mapper): Prevent generating GeneratedMapper with special characters

### DIFF
--- a/src/Metadata/MapperMetadata.php
+++ b/src/Metadata/MapperMetadata.php
@@ -8,6 +8,20 @@ use AutoMapper\AutoMapper;
 
 class MapperMetadata
 {
+    private const FORBIDEN_CHARACTERS_REPLACEMENT = [
+        '\\' => '_',
+        '/' => '_',
+        ':' => '_',
+        '*' => '_',
+        '?' => '_',
+        '"' => '_',
+        '<' => '_',
+        '>' => '_',
+        '|' => '_',
+        ' ' => '_',
+        '[]' => 'Array',
+    ];
+
     /** @var class-string<object> */
     public string $className;
 
@@ -42,7 +56,7 @@ class MapperMetadata
         }
 
         /** @var class-string<object> $className */
-        $className = sprintf('%s%s_%s', $this->classPrefix, str_replace('\\', '_', $this->source), str_replace('\\', '_', $this->target));
+        $className = sprintf('%s%s_%s', $this->classPrefix, str_replace(array_keys(self::FORBIDEN_CHARACTERS_REPLACEMENT), self::FORBIDEN_CHARACTERS_REPLACEMENT, $this->source), str_replace(array_keys(self::FORBIDEN_CHARACTERS_REPLACEMENT), self::FORBIDEN_CHARACTERS_REPLACEMENT, $this->target));
         $this->className = $className;
     }
 


### PR DESCRIPTION
Hello I've noticed that when we use special characters in `target` name it can prevent them from working.

Here's the error:
![image](https://github.com/jolicode/automapper/assets/72203064/0009e423-ea47-40b5-84ad-3a409ba9a475)

The code that throw this exception : 
```php
$newObjects = $autoMapper->map($array, ComplexObject::class . '[]');
```

Maybe is not necessary because `map` method don't support `[]` syntax, feel free to close if was a bad idea