### PR TITLE
fix: handle deprecated class LNumber in nikic/php-parser v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,10 @@
     "autoload": {
         "psr-4": {
             "AutoMapper\\": "src/"
-        }
+        },
+        "files": [
+            "src/php-parser.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Generator/CreateTargetStatementsGenerator.php
+++ b/src/Generator/CreateTargetStatementsGenerator.php
@@ -13,7 +13,6 @@ use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\PropertyMetadata;
 use AutoMapper\Transformer\AllowNullValueTransformerInterface;
 use PhpParser\Node\Arg;
-use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -22,10 +21,8 @@ use PhpParser\Node\Stmt;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 
-// compatibility with nikic/php-parser 4.x
-if (!class_exists(ArrayItem::class) && class_exists(Expr\ArrayItem::class)) {
-    class_alias(Expr\ArrayItem::class, ArrayItem::class);
-}
+use function AutoMapper\PhpParser\create_expr_array_item;
+use function AutoMapper\PhpParser\create_scalar_int;
 
 /**
  * @internal
@@ -193,10 +190,10 @@ final readonly class CreateTargetStatementsGenerator
         $defaultValueExpr = new Expr\Throw_(
             new Expr\New_(new Name\FullyQualified(MissingConstructorArgumentsException::class), [
                 new Arg(new Scalar\String_(sprintf('Cannot create an instance of "%s" from mapping data because its constructor requires the following parameters to be present : "$%s".', $metadata->mapperMetadata->target, $propertyMetadata->target->property))),
-                new Arg(new Scalar\LNumber(0)),
+                new Arg(create_scalar_int(0)),
                 new Arg(new Expr\ConstFetch(new Name('null'))),
-                new Arg(new Expr\Array_([
-                    new ArrayItem(new Scalar\String_($propertyMetadata->target->property)),
+                new Arg(new Expr\Array_([ // @phpstan-ignore argument.type
+                    create_expr_array_item(new Scalar\String_($propertyMetadata->target->property)),
                 ])),
                 new Arg(new Scalar\String_($metadata->mapperMetadata->target)),
             ])
@@ -256,10 +253,10 @@ final readonly class CreateTargetStatementsGenerator
 
         $defaultValueExpr = new Expr\Throw_(new Expr\New_(new Name\FullyQualified(MissingConstructorArgumentsException::class), [
             new Arg(new Scalar\String_(sprintf('Cannot create an instance of "%s" from mapping data because its constructor requires the following parameters to be present : "$%s".', $metadata->mapperMetadata->target, $constructorParameter->getName()))),
-            new Arg(new Scalar\LNumber(0)),
+            new Arg(create_scalar_int(0)),
             new Arg(new Expr\ConstFetch(new Name('null'))),
-            new Arg(new Expr\Array_([
-                new ArrayItem(new Scalar\String_($constructorParameter->getName())),
+            new Arg(new Expr\Array_([ // @phpstan-ignore argument.type
+                create_expr_array_item(new Scalar\String_($constructorParameter->getName())),
             ])),
             new Arg(new Scalar\String_($constructorParameter->getName())),
         ]));

--- a/src/Generator/PropertyConditionsGenerator.php
+++ b/src/Generator/PropertyConditionsGenerator.php
@@ -9,7 +9,6 @@ use AutoMapper\MapperContext;
 use AutoMapper\Metadata\GeneratorMetadata;
 use AutoMapper\Metadata\PropertyMetadata;
 use PhpParser\Node\Arg;
-use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
@@ -18,10 +17,8 @@ use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
-// compatibility with nikic/php-parser 4.x
-if (!class_exists(ArrayItem::class) && class_exists(Expr\ArrayItem::class)) {
-    class_alias(Expr\ArrayItem::class, ArrayItem::class);
-}
+use function AutoMapper\PhpParser\create_expr_array_item;
+use function AutoMapper\PhpParser\create_scalar_int;
 
 /**
  * We generate a list of conditions that will allow the field to be mapped to the target.
@@ -175,8 +172,8 @@ final readonly class PropertyConditionsGenerator
                         new Expr\Array_()
                     )
                 ),
-                new Arg(new Expr\Array_(array_map(function (string $group) {
-                    return new ArrayItem(new Scalar\String_($group));
+                new Arg(new Expr\Array_(array_map(function (string $group) { // @phpstan-ignore argument.type
+                    return create_expr_array_item(new Scalar\String_($group));
                 }, $groups))),
             ])
         );
@@ -228,7 +225,7 @@ final readonly class PropertyConditionsGenerator
                 new Expr\ArrayDimFetch($variableRegistry->getContext(), new Scalar\String_(MapperContext::DEPTH)),
                 new Expr\ConstFetch(new Name('0'))
             ),
-            new Scalar\LNumber($propertyMetadata->maxDepth)
+            create_scalar_int($propertyMetadata->maxDepth),
         );
     }
 

--- a/src/Transformer/ArrayTransformer.php
+++ b/src/Transformer/ArrayTransformer.php
@@ -9,7 +9,8 @@ use AutoMapper\Metadata\PropertyMetadata;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar;
+
+use function AutoMapper\PhpParser\create_scalar_int;
 
 /**
  * Transformer array decorator.
@@ -43,14 +44,12 @@ final readonly class ArrayTransformer extends AbstractArrayTransformer implement
             ]
         );
 
-        $intScalar = class_exists(Scalar\Int_::class) ? new Scalar\Int_(0) : new Scalar\LNumber(0);
-
         if ($this->itemTransformer instanceof CheckTypeInterface) {
             $itemCheck = $this->itemTransformer->getCheckExpression(new Expr\FuncCall(new Name('current'), [new Arg($input)]), $target, $propertyMapping, $uniqueVariableScope, $source);
 
             if ($itemCheck) {
                 return new Expr\BinaryOp\BooleanAnd($isArrayCheck, new Expr\BinaryOp\BooleanOr(
-                    new Expr\BinaryOp\Identical($intScalar, new Expr\FuncCall(new Name('count'), [new Arg($input)])),
+                    new Expr\BinaryOp\Identical(create_scalar_int(0), new Expr\FuncCall(new Name('count'), [new Arg($input)])),
                     $itemCheck
                 ));
             }

--- a/src/Transformer/BuiltinTransformer.php
+++ b/src/Transformer/BuiltinTransformer.php
@@ -7,16 +7,12 @@ namespace AutoMapper\Transformer;
 use AutoMapper\Generator\UniqueVariableScope;
 use AutoMapper\Metadata\PropertyMetadata;
 use PhpParser\Node\Arg;
-use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Name;
 use Symfony\Component\PropertyInfo\Type;
 
-// compatibility with nikic/php-parser 4.x
-if (!class_exists(ArrayItem::class) && class_exists(Expr\ArrayItem::class)) {
-    class_alias(Expr\ArrayItem::class, ArrayItem::class);
-}
+use function AutoMapper\PhpParser\create_expr_array_item;
 
 /**
  * Built in transformer to handle PHP scalar types.
@@ -140,7 +136,7 @@ final readonly class BuiltinTransformer implements TransformerInterface, CheckTy
 
     private function toArray(Expr $input): Expr
     {
-        return new Expr\Array_([new ArrayItem($input)]);
+        return new Expr\Array_([create_expr_array_item($input)]); // @phpstan-ignore argument.type
     }
 
     private function fromIteratorToArray(Expr $input): Expr

--- a/src/php-parser.php
+++ b/src/php-parser.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file provides compatibility functions for nikic/php-parser v4 & v5.
+ */
+
+declare(strict_types=1);
+
+namespace AutoMapper\PhpParser;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+
+/**
+ * Constructs an integer number scalar node.
+ *
+ * @param int                  $value      Value of the number
+ * @param array<string, mixed> $attributes Additional attributes
+ */
+function create_scalar_int(int $value, array $attributes = []): Scalar\Int_|Scalar\LNumber
+{
+    $class = class_exists(Scalar\Int_::class) ? Scalar\Int_::class : Scalar\LNumber::class;
+
+    return new $class($value, $attributes);
+}
+
+/**
+ * Constructs an array item node.
+ *
+ * @param Expr                 $value      Value
+ * @param Expr|null            $key        Key
+ * @param bool                 $byRef      Whether to assign by reference
+ * @param array<string, mixed> $attributes Additional attributes
+ */
+function create_expr_array_item(Expr $value, Expr $key = null, bool $byRef = false, array $attributes = [], bool $unpack = false): Node\ArrayItem|Expr\ArrayItem
+{
+    $class = class_exists(Node\ArrayItem::class) ? Node\ArrayItem::class : Expr\ArrayItem::class;
+
+    return new $class($value, $key, $byRef, $attributes, $unpack);
+}

--- a/tools/phpstan/composer.lock
+++ b/tools/phpstan/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.60",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "95dcea7d6c628a3f2f56d091d8a0219485a86bbe"
+                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/95dcea7d6c628a3f2f56d091d8a0219485a86bbe",
-                "reference": "95dcea7d6c628a3f2f56d091d8a0219485a86bbe",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e524358f930e41a2b4cca1320e3b04fc26b39e0b",
+                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b",
                 "shasum": ""
             },
             "require": {
@@ -60,13 +60,9 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-07T13:30:19+00:00"
+            "time": "2024-05-15T08:00:59+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
I think since the `Automapper` is the only entrypoint of this whole lib, we can add `class_alias()` in this class, and problem would be solved.

WDYT?