### PR TITLE
docs: fix typo

### DIFF
--- a/docs/bundle/cache-warmup.md
+++ b/docs/bundle/cache-warmup.md
@@ -13,7 +13,7 @@ To avoid this problem, you can specify the mappings you want to generate in the 
 
 ```yaml
 automapper:
-  mappings:
+  mapping:
     mappers:
       - source: App\Entity\User
         target: App\Api\DTO\User
@@ -36,7 +36,7 @@ You can also define a list of paths where the mappers are located, and the bundl
 
 ```yaml
 automapper:
-  mappings:
+  mapping:
     paths:
       - "%kernel.project_dir%/src/Entity"
 ```


### PR DESCRIPTION
regarding [the declared configuration](https://github.com/jolicode/automapper/blob/main/src/Symfony/Bundle/DependencyInjection/Configuration.php#L56) the right key is `mapping` and not `mappings`