### PR TITLE
fix(bundle): actually read reload_strategy from bundle configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [GH#153](https://github.com/jolicode/automapper/pull/153) Handle DateTime format in MapTo/MapFrom/Mapper attributes
 
+### Fixed
+- [GH#158](https://github.com/jolicode/automapper/pull/158) Actually read reload_strategy from bundle configuration
+
 ## [9.0.2] - 2024-05-23
 ### Deprecated
 - [GH#136](https://github.com/jolicode/automapper/pull/136) Deprecate the ability to inject AST transformer factories withing stand-alone AutoMapper

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "api-platform/core": "^3.0.4",
         "doctrine/annotations": "~1.0",
         "doctrine/inflector": "^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^5.1",
         "moneyphp/money": "^3.3.2",
         "phpunit/phpunit": "^9.0",
         "symfony/browser-kit": "^6.4 || ^7.0",

--- a/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
@@ -75,7 +75,7 @@ class AutoMapperExtension extends Extension
             ;
         } else {
             $isDebug = $container->getParameter('kernel.debug');
-            $generateStrategy = $config['loader']['reload_strategy'] ?? $isDebug ? FileReloadStrategy::ALWAYS->value : FileReloadStrategy::NEVER->value;
+            $generateStrategy = $config['loader']['reload_strategy'] ?? ($isDebug ? FileReloadStrategy::ALWAYS->value : FileReloadStrategy::NEVER->value);
             $generateStrategy = FileReloadStrategy::tryFrom($generateStrategy);
 
             $container

--- a/tests/Bundle/DependencyInjection/AutoMapperExtensionTest.php
+++ b/tests/Bundle/DependencyInjection/AutoMapperExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Bundle\DependencyInjection;
+
+use AutoMapper\Loader\FileLoader;
+use AutoMapper\Loader\FileReloadStrategy;
+use AutoMapper\Symfony\Bundle\DependencyInjection\AutoMapperExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class AutoMapperExtensionTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->setParameter('kernel.environment', 'prod');
+    }
+
+    /**
+     * @dataProvider provideReloadStrategyConfiguration
+     */
+    public function testItCorrectlyConfiguresReloadStrategy(array $config, bool $debug, FileReloadStrategy $expectedValue): void
+    {
+        $this->container->setParameter('kernel.debug', $debug);
+        $this->load(['loader' => $config]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(FileLoader::class, 3, $expectedValue);
+    }
+
+    public static function provideReloadStrategyConfiguration(): iterable
+    {
+        yield 'Never reload if no conf and no debug' => [[], false, FileReloadStrategy::NEVER];
+        yield 'Always reload if no conf and no debug' => [[], true, FileReloadStrategy::ALWAYS];
+        yield 'Applies configured reload strategy if provided' => [['reload_strategy' => FileReloadStrategy::NEVER->value], true, FileReloadStrategy::NEVER];
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [new AutoMapperExtension()];
+    }
+}


### PR DESCRIPTION
Currently, because of parameter precedence, `$reloadStrategy` is never read from bundle config and always default to `ALWAYS` :see_no_evil: 