### PR TITLE
docs: Fix property metadata attribute name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- [GH#167](https://github.com/jolicode/automapper/pull/167) Fix property metadata attribute name in docs
 - [GH#166](https://github.com/jolicode/automapper/pull/166) Remove cache for property info, use specific services instead
 
 ## [9.1.1] - 2024-06-19

--- a/docs/mapping/transformer.md
+++ b/docs/mapping/transformer.md
@@ -144,7 +144,7 @@ class UrlTransformer implements PropertyTransformerInterface, PropertyTransforme
             return false;
         }
 
-        return $sourceUniqueType->getBuiltinType() === 'int' && $source->name === 'id' && $target->name === 'url';
+        return $sourceUniqueType->getBuiltinType() === 'int' && $source->property === 'id' && $target->property === 'url';
     }
     
     public function transform(mixed $value, object|array $source, array $context): mixed


### PR DESCRIPTION
Metadata property is named `property`, not `name` anymore :wink: 