### PR TITLE
feat(loader): lock load class on file loader to avoid race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- [GH#174](https://github.com/jolicode/automapper/pull/174) Fix race condition when writing generated mappers
 - [GH#167](https://github.com/jolicode/automapper/pull/167) Fix property metadata attribute name in docs
 - [GH#166](https://github.com/jolicode/automapper/pull/166) Remove cache for property info, use specific services instead
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/deprecation-contracts": "^3.0",
         "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/expression-language": "^6.4 || ^7.0",
+        "symfony/lock": "^6.4 || ^7.0",
         "symfony/property-info": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "phpdocumentor/type-resolver": "^1.7"

--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -22,6 +22,8 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -181,10 +183,12 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
             $expressionLanguage,
         );
 
+        $lockFactory = new LockFactory(new FlockStore());
+
         if (null === $cacheDirectory) {
             $loader = new EvalLoader($mapperGenerator, $metadataFactory);
         } else {
-            $loader = new FileLoader($mapperGenerator, $metadataFactory, $cacheDirectory);
+            $loader = new FileLoader($mapperGenerator, $metadataFactory, $cacheDirectory, $lockFactory);
         }
 
         return new self($loader, $customTransformerRegistry, $metadataRegistry, $providerRegistry, $expressionLanguageProvider);

--- a/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/AutoMapperExtension.php
@@ -89,7 +89,7 @@ class AutoMapperExtension extends Extension
 
             $container
                 ->getDefinition(FileLoader::class)
-                ->replaceArgument(3, $generateStrategy);
+                ->replaceArgument(4, $generateStrategy);
 
             $container
                 ->setAlias(ClassLoaderInterface::class, FileLoader::class)

--- a/src/Symfony/Bundle/Resources/config/automapper.php
+++ b/src/Symfony/Bundle/Resources/config/automapper.php
@@ -12,10 +12,13 @@ use AutoMapper\Generator\MapperGenerator;
 use AutoMapper\Loader\ClassLoaderInterface;
 use AutoMapper\Loader\EvalLoader;
 use AutoMapper\Loader\FileLoader;
+use AutoMapper\Loader\FileReloadStrategy;
 use AutoMapper\Metadata\MetadataFactory;
 use AutoMapper\Provider\ProviderRegistry;
 use AutoMapper\Symfony\ExpressionLanguageProvider;
 use AutoMapper\Transformer\PropertyTransformer\PropertyTransformerRegistry;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -30,6 +33,13 @@ return static function (ContainerConfigurator $container) {
             ->alias(AutoMapperInterface::class, AutoMapper::class)->public()
             ->alias(AutoMapperRegistryInterface::class, AutoMapper::class)->public()
 
+        ->set('automapper.file_loader_lock_factory_store')
+            ->class(FlockStore::class)
+        ->set('automapper.file_loader_lock_factory')
+            ->class(LockFactory::class)
+            ->args([
+                service('automapper.file_loader_lock_factory_store'),
+            ])
         ->set(EvalLoader::class)
             ->args([
                 service(MapperGenerator::class),
@@ -41,7 +51,8 @@ return static function (ContainerConfigurator $container) {
                 service(MapperGenerator::class),
                 service(MetadataFactory::class),
                 '%kernel.cache_dir%/automapper',
-                true,
+                service('automapper.file_loader_lock_factory'),
+                FileReloadStrategy::ALWAYS,
             ])
 
         ->set(Configuration::class)

--- a/tests/Bundle/DependencyInjection/AutoMapperExtensionTest.php
+++ b/tests/Bundle/DependencyInjection/AutoMapperExtensionTest.php
@@ -29,7 +29,7 @@ final class AutoMapperExtensionTest extends AbstractExtensionTestCase
         $this->container->setParameter('kernel.debug', $debug);
         $this->load(['loader' => $config]);
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(FileLoader::class, 3, $expectedValue);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(FileLoader::class, 4, $expectedValue);
     }
 
     public static function provideReloadStrategyConfiguration(): iterable


### PR DESCRIPTION
There can be race condition when multiple php process would generate the class at the same time, so we add a lock here to avoid this problem

[Better diff with `?w=1`](https://github.com/jolicode/automapper/pull/174/files?w=1)