### PR TITLE
Constructor with default paramater array does not work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ jobs:
           php-version: 8.2
           coverage: none
       - name: install PHP CS Fixer
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: '--working-dir=tools/php-cs-fixer'
+        run: 'composer install -n --prefer-dist --optimize-autoloader --working-dir=tools/php-cs-fixer'
       - name: 'php-cs-fixer check'
         run: 'tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=tools/php-cs-fixer/.php-cs-fixer.php --dry-run --diff'
   phpstan:
@@ -35,9 +33,7 @@ jobs:
       - name: composer install
         run: composer update --prefer-stable
       - name: install phpstan
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: '--working-dir=tools/phpstan'
+        run: 'composer install -n --prefer-dist --optimize-autoloader --working-dir=tools/phpstan'
       - name: 'phpstan check'
         run: 'tools/phpstan/vendor/bin/phpstan analyse --configuration=tools/phpstan/phpstan.neon'
   tests:

--- a/src/Generator/CreateTargetStatementsGenerator.php
+++ b/src/Generator/CreateTargetStatementsGenerator.php
@@ -205,6 +205,14 @@ final readonly class CreateTargetStatementsGenerator
             $defaultValueExpr = new Expr\ConstFetch(new Name('null'));
         }
 
+        if ($defaultValueExpr instanceof Expr\Array_) {
+            // $constructarg_3 = count($values) > 0 ? $values : array();
+            $argumentAssignedValue = new Expr\Ternary(new Expr\BinaryOp\Greater(new Expr\FuncCall(new Name('count'), [new Arg($output)]), create_scalar_int(0)), $output, $defaultValueExpr);
+        } else {
+            // $constructarg_0 = $values ?? array();
+            $argumentAssignedValue = new Expr\BinaryOp\Coalesce($output, $defaultValueExpr);
+        }
+
         return [
             new Stmt\If_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'hasConstructorArgument', [
                 new Arg($variableRegistry->getContext()),
@@ -221,7 +229,7 @@ final readonly class CreateTargetStatementsGenerator
                 ],
                 'else' => new Stmt\Else_([
                     ...$propStatements,
-                    new Stmt\Expression(new Expr\Assign($constructVar, new Expr\BinaryOp\Coalesce($output, $defaultValueExpr))),
+                    new Stmt\Expression(new Expr\Assign($constructVar, $argumentAssignedValue)),
                 ]),
             ]),
             new Arg($constructVar, name: new Identifier($parameter->getName())),

--- a/src/Transformer/AbstractArrayTransformer.php
+++ b/src/Transformer/AbstractArrayTransformer.php
@@ -67,7 +67,7 @@ abstract readonly class AbstractArrayTransformer implements TransformerInterface
             $itemStatements[] = new Stmt\Expression($this->getAssignExpr($valuesVar, $output, $loopKeyVar, $assignByRef));
         }
 
-        $statements[] = new Stmt\Foreach_($input, $loopValueVar, [
+        $statements[] = new Stmt\Foreach_(new Expr\BinaryOp\Coalesce($input, new Expr\Array_()), $loopValueVar, [
             'stmts' => $itemStatements,
             'keyVar' => $loopKeyVar,
         ]);

--- a/tests/Fixtures/ConstructorWithDefaultValues.php
+++ b/tests/Fixtures/ConstructorWithDefaultValues.php
@@ -9,7 +9,8 @@ readonly class ConstructorWithDefaultValues
     public function __construct(
         public string $baz,
         public ?int $foo = 1,
-        public int $bar = 0
+        public int $bar = 0,
+        public array $someOtters = [],
     ) {
     }
 }


### PR DESCRIPTION
When using an argument with a default array value in a constructor, AutoMapper had issues using the default value if you pass no values in the `->map()` input.

Before:
```php
            if (\AutoMapper\MapperContext::hasConstructorArgument($context, 'AppBundle\\Entity\\Crawl\\Metadata\\Stats\\Stats', 'fourreTout')) {
                $values_2 = array();
                foreach ($value['fourreTout'] as $key_2 => $value_3) {
                    $values_2[$key_2] = $value_3;
                }
                $constructarg_8 = $values_2 ?? \AutoMapper\MapperContext::getConstructorArgument($context, 'AppBundle\\Entity\\Crawl\\Metadata\\Stats\\Stats', 'fourreTout');
            } else {
                $values_2 = array();
                foreach ($value['fourreTout'] as $key_2 => $value_3) {
                    $values_2[$key_2] = $value_3;
                }
                $constructarg_8 = $values_2 ?? array();
            }
```

After:
```php
            if (\AutoMapper\MapperContext::hasConstructorArgument($context, 'AutoMapper\Tests\Fixtures\ConstructorWithDefaultValues', 'someOtters')) {
                $values = [];
                foreach ($value['someOtters'] ?? [] as $key => $value_2) {
                    $values[$key] = $value_2;
                }
                $constructarg_3 = $values ?? \AutoMapper\MapperContext::getConstructorArgument($context, 'AutoMapper\Tests\Fixtures\ConstructorWithDefaultValues', 'someOtters');
            } else {
                $values = [];
                foreach ($value['someOtters'] ?? [] as $key => $value_2) {
                    $values[$key] = $value_2;
                }
                $constructarg_3 = count($values) > 0 ? $values : array();
            }
```