### PR TITLE
feat: option to generate code with strict types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [GH#180](https://github.com/jolicode/automapper/pull/180) Add configuration to generate code with strict types
+
 ### Fixed
 - [GH#167](https://github.com/jolicode/automapper/pull/167) Fix property metadata attribute name in docs
 - [GH#166](https://github.com/jolicode/automapper/pull/166) Remove cache for property info, use specific services instead

--- a/src/Attribute/Mapper.php
+++ b/src/Attribute/Mapper.php
@@ -23,6 +23,7 @@ final readonly class Mapper
         public ?bool $checkAttributes = null,
         public ?ConstructorStrategy $constructorStrategy = null,
         public ?bool $allowReadOnlyTargetToPopulate = null,
+        public ?bool $strictTypes = null,
         public int $priority = 0,
         public ?string $dateTimeFormat = null,
     ) {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -36,6 +36,10 @@ final readonly class Configuration
          * Does the mapper should throw an exception if the target is read-only.
          */
         public bool $allowReadOnlyTargetToPopulate = false,
+        /**
+         * Add declare(strict_types=1) to generated code.
+         */
+        public bool $strictTypes = false,
     ) {
     }
 }

--- a/src/Event/GenerateMapperEvent.php
+++ b/src/Event/GenerateMapperEvent.php
@@ -22,6 +22,7 @@ final class GenerateMapperEvent
         public ?bool $checkAttributes = null,
         public ?ConstructorStrategy $constructorStrategy = null,
         public ?bool $allowReadOnlyTargetToPopulate = null,
+        public ?bool $strictTypes = null,
     ) {
     }
 }

--- a/src/EventListener/MapperListener.php
+++ b/src/EventListener/MapperListener.php
@@ -72,6 +72,7 @@ final readonly class MapperListener
         $event->checkAttributes ??= $mapper->checkAttributes;
         $event->constructorStrategy ??= $mapper->constructorStrategy;
         $event->allowReadOnlyTargetToPopulate ??= $mapper->allowReadOnlyTargetToPopulate;
+        $event->strictTypes ??= $mapper->strictTypes;
         $event->mapperMetadata->dateTimeFormat = $mapper->dateTimeFormat;
     }
 }

--- a/src/Loader/EvalLoader.php
+++ b/src/Loader/EvalLoader.php
@@ -31,9 +31,9 @@ final readonly class EvalLoader implements ClassLoaderInterface
 
     public function loadClass(MapperMetadata $mapperMetadata): void
     {
-        $class = $this->generator->generate($this->metadataFactory->getGeneratorMetadata($mapperMetadata->source, $mapperMetadata->target));
-
-        eval($this->printer->prettyPrint([$class]));
+        eval($this->printer->prettyPrint($this->generator->generate(
+            $this->metadataFactory->getGeneratorMetadata($mapperMetadata->source, $mapperMetadata->target)
+        )));
     }
 
     public function buildMappers(MetadataRegistry $registry): bool

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -78,8 +78,9 @@ final class FileLoader implements ClassLoaderInterface
         $className = $mapperMetadata->className;
         $classPath = $this->directory . \DIRECTORY_SEPARATOR . $className . '.php';
 
-        $generatorMetadata = $this->metadataFactory->getGeneratorMetadata($mapperMetadata->source, $mapperMetadata->target);
-        $classCode = $this->printer->prettyPrint([$this->generator->generate($generatorMetadata)]);
+        $classCode = $this->printer->prettyPrint($this->generator->generate(
+            $this->metadataFactory->getGeneratorMetadata($mapperMetadata->source, $mapperMetadata->target)
+        ));
 
         $this->write($classPath, "<?php\n\n" . $classCode . "\n");
 

--- a/src/Metadata/GeneratorMetadata.php
+++ b/src/Metadata/GeneratorMetadata.php
@@ -24,7 +24,8 @@ final class GeneratorMetadata
         public readonly array $propertiesMetadata,
         public readonly bool $checkAttributes = true,
         public readonly ConstructorStrategy $constructorStrategy = ConstructorStrategy::AUTO,
-        public bool $allowReadOnlyTargetToPopulate = false,
+        public readonly bool $allowReadOnlyTargetToPopulate = false,
+        public readonly bool $strictTypes = false,
         public readonly ?string $provider = null,
     ) {
         $this->variableRegistry = new VariableRegistry();

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -312,6 +312,7 @@ final class MetadataFactory
             $mapperEvent->checkAttributes ?? $this->configuration->attributeChecking,
             $mapperEvent->constructorStrategy ?? $this->configuration->constructorStrategy,
             $mapperEvent->allowReadOnlyTargetToPopulate ?? $this->configuration->allowReadOnlyTargetToPopulate,
+            $mapperEvent->strictTypes ?? $this->configuration->strictTypes,
             $mapperEvent->provider,
         );
     }

--- a/src/php-parser.php
+++ b/src/php-parser.php
@@ -43,3 +43,19 @@ function create_expr_array_item(Expr $value, Expr $key = null, bool $byRef = fal
 
     return new $class($value, $key, $byRef, $attributes, $unpack);
 }
+
+/**
+ * Constructs a declare key=>value pair node.
+ *
+ * @param string|Node\Identifier $key        Key
+ * @param Expr                   $value      Value
+ * @param array<string, mixed>   $attributes Additional attributes
+ *
+ * @internal
+ */
+function create_declare_item($key, Expr $value, array $attributes = []): Node\DeclareItem|Node\Stmt\DeclareDeclare
+{
+    $class = class_exists(Node\DeclareItem::class) ? Node\DeclareItem::class : Node\Stmt\DeclareDeclare::class;
+
+    return new $class($key, $value, $attributes);
+}

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -785,6 +785,24 @@ class AutoMapperTest extends AutoMapperBaseTest
         $automapper->getMapper(Fixtures\User::class, Fixtures\UserDTO::class);
     }
 
+    public function testStrictTypes(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        $automapper = AutoMapper::create(new Configuration(strictTypes: true, classPrefix: 'StrictTypes_'));
+        $data = ['foo' => 1.1];
+        $automapper->map($data, Fixtures\IntDTO::class);
+    }
+
+    public function testStrictTypesFromMapper(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        $automapper = AutoMapper::create(new Configuration(strictTypes: false, classPrefix: 'StrictTypesFromMapper_'));
+        $data = ['foo' => 1.1];
+        $automapper->map($data, Fixtures\IntDTOWithMapper::class);
+    }
+
     public function testWithMixedArray(): void
     {
         $user = new Fixtures\User(1, 'yolo', '13');

--- a/tests/Fixtures/IntDTO.php
+++ b/tests/Fixtures/IntDTO.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+readonly class IntDTO
+{
+    public function __construct(
+        public int $foo,
+    ) {
+    }
+}

--- a/tests/Fixtures/IntDTOWithMapper.php
+++ b/tests/Fixtures/IntDTOWithMapper.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+use AutoMapper\Attribute\Mapper;
+
+#[Mapper(strictTypes: true)]
+readonly class IntDTOWithMapper
+{
+    public function __construct(
+        public int $foo,
+    ) {
+    }
+}


### PR DESCRIPTION
PHP, by default, will coerce values of the wrong type into the expected scalar type declaration if possible. This leads to unexpected behavior. For example, losing decimal digits when casting float to int
```PHP
readonly class IntDto
{
    public function __construct(
        public int $var,
    ) {}
}

$autoMapper = \AutoMapper\AutoMapper::create();
$result = $autoMapper->map(['var' => 1.1111], IntDto::class);
$result->var; // var is 1
```
This PR adds configuration to add `declare(strict_types=1)` to generated code when mapping, so instead of unexpected behavior, you get TypeError.

If everything is ok, I will update the docs, but I am not very fluent with english, so maybe someone else could write a more understandable description.