### PR TITLE
fix: error when mapping from stdClass to constructor with nullable/optional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [GH#180](https://github.com/jolicode/automapper/pull/180) Add configuration to generate code with strict types
 
+### Fixed
+- [GH#184](https://github.com/jolicode/automapper/pull/184) Fix error when mapping from stdClass to constructor with nullable/optional arguments
+
 ## [9.1.2] - 2024-09-03
 ### Fixed
 - [GH#174](https://github.com/jolicode/automapper/pull/174) Fix race condition when writing generated mappers
@@ -157,7 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [GH#22](https://github.com/jolicode/automapper/pull/22) Added generic AST extractor
 - [GH#21](https://github.com/jolicode/automapper/pull/21) Add VERSION constants within AutoMapper class and use it for transformers hashes
- 
+
 ### Changed
 - [GH#19](https://github.com/jolicode/automapper/pull/19) Use attributes everywhere instead of annotations
 - [GH#18](https://github.com/jolicode/automapper/pull/18) Symfony 7 support

--- a/src/Transformer/NullableTransformerFactory.php
+++ b/src/Transformer/NullableTransformerFactory.php
@@ -21,6 +21,10 @@ final class NullableTransformerFactory implements TransformerFactoryInterface, P
 
     public function getTransformer(TypesMatching $types, SourcePropertyMetadata $source, TargetPropertyMetadata $target, MapperMetadata $mapperMetadata): ?TransformerInterface
     {
+        if (null !== $target->parameterInConstructor) {
+            return null;
+        }
+
         $sourceType = $types->getSourceUniqueType();
 
         if (null === $sourceType) {

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -525,6 +525,15 @@ class AutoMapperTest extends AutoMapperBaseTest
         $this->autoMapper->map($data, ConstructorWithDefaultValues::class);
     }
 
+    public function testConstructorWithDefaultFromStdClass(): void
+    {
+        $data = (object) ['baz' => 'baz'];
+        /** @var ConstructorWithDefaultValues $object */
+        $object = $this->autoMapper->map($data, ConstructorWithDefaultValues::class);
+
+        self::assertInstanceOf(ConstructorWithDefaultValues::class, $object);
+    }
+
     public function testConstructorWithDefault(): void
     {
         $user = new Fixtures\UserDTONoAge();


### PR DESCRIPTION
I was trying to understand why generated code looks weird when mapping from array/stdClass to class which has constructor with nullable/optional arguments.
NullableTransformer is not supposed to be applied when creating from constructor because nullable/optional already handled.

With this fix, generated code instead of looking like this:
```PHP
$value_1 = null;
if (null !== $value->ResponseDescription) {
    $value_1 = $value->ResponseDescription;
}
$constructarg_1 = $value_1 ?? NULL;
``` 
Look like this:
```PHP
$constructarg_1 = $value->ResponseDescription ?? NULL;
```

Which also fixes #181 