### PR TITLE
fix: constructor with default parameter array does not work with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [GH#184](https://github.com/jolicode/automapper/pull/184) Fix error when mapping from stdClass to constructor with nullable/optional arguments
+- [GH#185](https://github.com/jolicode/automapper/pull/185) Fix constructor with default parameter array does not work with constructor_arguments context
 
 ## [9.1.2] - 2024-09-03
 ### Fixed

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -469,6 +469,19 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertTrue($userDto->getConstructor());
     }
 
+    public function testConstructorArrayArgumentFromContext(): void
+    {
+        $data = ['baz' => 'baz'];
+        /** @var ConstructorWithDefaultValues $userDto */
+        $object = $this->autoMapper->map($data, ConstructorWithDefaultValues::class, [MapperContext::CONSTRUCTOR_ARGUMENTS => [
+            ConstructorWithDefaultValues::class => ['someOtters' => [1]],
+        ]]);
+
+        self::assertInstanceOf(ConstructorWithDefaultValues::class, $object);
+        self::assertSame('baz', $object->baz);
+        self::assertSame([1], $object->someOtters);
+    }
+
     public function testConstructorNotAllowed(): void
     {
         $this->buildAutoMapper(mapPrivatePropertiesAndMethod: true, constructorStrategy: ConstructorStrategy::NEVER, classPrefix: 'NotAllowedMapper_');


### PR DESCRIPTION
After this PR #177 behavior was fixed when not using constructor arguments context, but with context it's still uses `??`.

Before:
```PHP
if (\AutoMapper\MapperContext::hasConstructorArgument($context, 'ConstructorWithDefaultValues', 'someOtters')) {
    $values = [];
    foreach ($value['someOtters'] ?? [] as $key => $value) {
        $values[$key] = $value;
    }
    $constructarg = $values ?? \AutoMapper\MapperContext::getConstructorArgument($context, 'ConstructorWithDefaultValues', 'someOtters');
} else {
    $values = [];
    foreach ($value['someOtters'] ?? [] as $key => $value) {
        $values[$key] = $value;
    }
    $constructarg = count($values) > 0 ? $values : array();
}
```
After:
```PHP
if (\AutoMapper\MapperContext::hasConstructorArgument($context, 'ConstructorWithDefaultValues', 'someOtters')) {
    $values = [];
    foreach ($value['someOtters'] ?? [] as $key => $value) {
        $values[$key] = $value;
    }
    $constructarg = count($values) > 0 ? $values : \AutoMapper\MapperContext::getConstructorArgument($context, 'ConstructorWithDefaultValues', 'someOtters');
} else {
    $values = [];
    foreach ($value['someOtters'] ?? [] as $key => $value) {
        $values[$key] = $value;
    }
    $constructarg = count($values) > 0 ? $values : array();
}
```