### PR TITLE
fix: regression after #184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [GH#184](https://github.com/jolicode/automapper/pull/184) Fix error when mapping from stdClass to constructor with nullable/optional arguments
 - [GH#185](https://github.com/jolicode/automapper/pull/185) Fix constructor with default parameter array does not work with constructor_arguments context
+- [GH#187](https://github.com/jolicode/automapper/pull/187) Fix regression after [GH#184](https://github.com/jolicode/automapper/pull/184)
 
 ## [9.1.2] - 2024-09-03
 ### Fixed

--- a/src/Transformer/NullableTransformer.php
+++ b/src/Transformer/NullableTransformer.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 /**
- * Tansformer decorator to handle null values.
+ * Transformer decorator to handle null values.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  *
@@ -51,9 +51,9 @@ final readonly class NullableTransformer implements TransformerInterface, Depend
             $itemStatements[] = new Stmt\Expression(new $assignClass($newOutput, $output));
         }
 
-        if ($input instanceof Expr\ArrayDimFetch) {
+        if ($propertyMapping->source->checkExists) {
             /*
-             * if `$input` is an array access, let's validate if the array key exists and is not null:
+             * if `$input` is an array access or stdClass, let's validate if the key exists and is not null:
              *
              * if (isset($value['key'])) {
              */

--- a/src/Transformer/NullableTransformerFactory.php
+++ b/src/Transformer/NullableTransformerFactory.php
@@ -21,10 +21,6 @@ final class NullableTransformerFactory implements TransformerFactoryInterface, P
 
     public function getTransformer(TypesMatching $types, SourcePropertyMetadata $source, TargetPropertyMetadata $target, MapperMetadata $mapperMetadata): ?TransformerInterface
     {
-        if (null !== $target->parameterInConstructor) {
-            return null;
-        }
-
         $sourceType = $types->getSourceUniqueType();
 
         if (null === $sourceType) {

--- a/tests/Fixtures/ConstructorWithDefaultValues.php
+++ b/tests/Fixtures/ConstructorWithDefaultValues.php
@@ -11,6 +11,7 @@ readonly class ConstructorWithDefaultValues
         public ?int $foo = 1,
         public int $bar = 0,
         public array $someOtters = [],
+        public ?IntDTO $nullableObject = null,
     ) {
     }
 }


### PR DESCRIPTION
Turns out NullableTransformer is needed when creating from constructor if we have argument what expects nullable object