### PR TITLE
add icon to symfony profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [GH#180](https://github.com/jolicode/automapper/pull/180) Add configuration to generate code with strict types
 - [GH#183](https://github.com/jolicode/automapper/pull/183) Ability to change reload strategy from AutoMapper::create()
+- [GH#193](https://github.com/jolicode/automapper/pull/193) add icon to symfony profiler
 
 ### Fixed
 - [GH#184](https://github.com/jolicode/automapper/pull/184) Fix error when mapping from stdClass to constructor with nullable/optional arguments

--- a/src/Symfony/Bundle/Resources/views/DataCollector/icon.svg
+++ b/src/Symfony/Bundle/Resources/views/DataCollector/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="icon-tabler icons-tabler-outline icon-tabler-topology-full">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M20 18a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" />
+  <path d="M8 18a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" />
+  <path d="M8 6a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" />
+  <path d="M20 6a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" />
+  <path d="M6 8v8" />
+  <path d="M18 16v-8" />
+  <path d="M8 6h8" />
+  <path d="M16 18h-8" />
+  <path d="M7.5 7.5l9 9" />
+  <path d="M7.5 16.5l9 -9" />
+</svg>

--- a/src/Symfony/Bundle/Resources/views/DataCollector/metadata.html.twig
+++ b/src/Symfony/Bundle/Resources/views/DataCollector/metadata.html.twig
@@ -1,26 +1,28 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
-    {% set text %}
-        {% if collector.metadatas|length == 0 %}
-            <div class="sf-toolbar-info-piece">
-                <b>AutoMapper</b>
-                <span>No Mapper</span>
-            </div>
-        {% endif %}
-        {% for metadata in collector.metadatas %}
-            <div class="sf-toolbar-info-piece">
-                <b>AutoMapper</b>
-                <span>{{ metadata.source }} to {{ metadata.target }}</span>
-            </div>
-        {% endfor %}
-    {% endset %}
+    {% if collector.metadatas|length > 0 %}
+        {% set icon %}
+            {{ source('@AutoMapper/DataCollector/icon.svg') }}
+            <span class="sf-toolbar-value">{{ collector.metadatas|length }}</span>
+        {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
+        {% set text %}
+            {% for metadata in collector.metadatas %}
+                <div class="sf-toolbar-info-piece">
+                    <b>AutoMapper</b>
+                    <span>{{ metadata.source }} to {{ metadata.target }}</span>
+                </div>
+            {% endfor %}
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
+    {% endif %}
 {% endblock %}
 
 {% block menu %}
     <span class="label{{ collector.metadatas|length > 0 ? '' : ' disabled' }}">
+        <span class="icon">{{ source('@AutoMapper/DataCollector/icon.svg') }}</span>
         <strong>AutoMapper</strong>
         {% if collector.metadatas|length > 0 %}
             <span class="count">


### PR DESCRIPTION
- hide automapper from profiler if there's no map action
- add icon to symfony profiler

I'm using this icon https://tabler.io/icons/icon/topology-full let me know if the icon needs to be changed