### PR TITLE
Refacto: Remove the lib phpdocumentor/type-resolver that is not used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "symfony/expression-language": "^6.4 || ^7.0",
         "symfony/lock": "^6.4 || ^7.0",
         "symfony/property-info": "^6.4 || ^7.0",
-        "symfony/property-access": "^6.4 || ^7.0",
-        "phpdocumentor/type-resolver": "^1.7"
+        "symfony/property-access": "^6.4 || ^7.0"
     },
     "require-dev": {
         "api-platform/core": "^3.0.4",

--- a/src/Extractor/GetTypeTrait.php
+++ b/src/Extractor/GetTypeTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AutoMapper\Extractor;
 
-use phpDocumentor\Reflection\Types\ContextFactory;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
@@ -36,10 +35,6 @@ trait GetTypeTrait
         }
 
         if (!class_exists(PhpDocParser::class)) {
-            return null;
-        }
-
-        if (!class_exists(ContextFactory::class)) {
             return null;
         }
 


### PR DESCRIPTION
When we use the automapper on a Symfony project using ApiPlatform, we start having issue with the phpdocumentor. 

Base on my research, it's not use on the project and should be comletely remove.