### PR TITLE
Fix race condition in EvalLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GH#185](https://github.com/jolicode/automapper/pull/185) Fix constructor with default parameter array does not work with constructor_arguments context
 - [GH#187](https://github.com/jolicode/automapper/pull/187) Fix regression after [GH#184](https://github.com/jolicode/automapper/pull/184)
 - [GH#192](https://github.com/jolicode/automapper/pull/192) Fix source and context not passed to callable transformer
+- [GH#197](https://github.com/jolicode/automapper/pull/197) Fix race condition in EvalLoader
 
 ## [9.1.2] - 2024-09-03
 ### Fixed


### PR DESCRIPTION
When using swoole coroutines with eval loader, where is a possibility to get an error `Cannot declare class {class}, because the name is already in use`, because coroutines share memory and declared classes.
Can be tested like this
```php
require 'vendor/autoload.php';

readonly class Dto
{
    public function __construct(
        public int $id,
    ) {}
}

$mapper = \AutoMapper\AutoMapper::create();
$data = ['id' => 1];

\Co\run(static function () use ($mapper, $data) {
    for ($i=1; $i < 100_000; $i++) { 
        \Co\go(static fn () => $mapper->map($data, Dto::class));
    }
});
```