### PR TITLE
fix: signature of Map attributes `transformer` property

### DIFF
--- a/src/Attribute/MapFrom.php
+++ b/src/Attribute/MapFrom.php
@@ -11,14 +11,14 @@ namespace AutoMapper\Attribute;
 final readonly class MapFrom
 {
     /**
-     * @param class-string<object>|'array'|array<class-string<object>|'array'>|null $source         The specific source class name or array. If null this attribute will be used for all source classes.
-     * @param string|null                                                           $property       The source property name. If null, the target property name will be used.
-     * @param int|null                                                              $maxDepth       The maximum depth of the mapping. If null, the default max depth will be used.
-     * @param string|callable(mixed $value, object $object): mixed|null             $transformer    A transformer id or a callable that transform the value during mapping
-     * @param bool|null                                                             $ignore         If true, the property will be ignored during mapping
-     * @param string|null                                                           $if             The condition to map the property, using the expression language
-     * @param string[]|null                                                         $groups         The groups to map the property
-     * @param string|null                                                           $dateTimeFormat The date-time format to use when transforming this property
+     * @param class-string<object>|'array'|array<class-string<object>|'array'>|null                                    $source         The specific source class name or array. If null this attribute will be used for all source classes.
+     * @param string|null                                                                                              $property       The source property name. If null, the target property name will be used.
+     * @param int|null                                                                                                 $maxDepth       The maximum depth of the mapping. If null, the default max depth will be used.
+     * @param string|callable(mixed $value, object|array<string, mixed> $source, array<string, mixed> $context): mixed $transformer    A transformer id or a callable that transform the value during mapping
+     * @param bool|null                                                                                                $ignore         If true, the property will be ignored during mapping
+     * @param string|null                                                                                              $if             The condition to map the property, using the expression language
+     * @param string[]|null                                                                                            $groups         The groups to map the property
+     * @param string|null                                                                                              $dateTimeFormat The date-time format to use when transforming this property
      */
     public function __construct(
         public string|array|null $source = null,

--- a/src/Attribute/MapTo.php
+++ b/src/Attribute/MapTo.php
@@ -11,14 +11,14 @@ namespace AutoMapper\Attribute;
 final readonly class MapTo
 {
     /**
-     * @param class-string<object>|'array'|array<class-string<object>|'array'>|null $target         The specific target class name or array. If null this attribute will be used for all target classes.
-     * @param string|null                                                           $property       The target property name. If null, the source property name will be used.
-     * @param int|null                                                              $maxDepth       The maximum depth of the mapping. If null, the default max depth will be used.
-     * @param string|callable(mixed $value, object $object): mixed|null             $transformer    A transformer id or a callable that transform the value during mapping
-     * @param bool|null                                                             $ignore         If true, the property will be ignored during mapping
-     * @param string|null                                                           $if             The condition to map the property, using the expression language
-     * @param string[]|null                                                         $groups         The groups to map the property
-     * @param string|null                                                           $dateTimeFormat The date-time format to use when transforming this property
+     * @param class-string<object>|'array'|array<class-string<object>|'array'>|null                                    $target         The specific target class name or array. If null this attribute will be used for all target classes.
+     * @param string|null                                                                                              $property       The target property name. If null, the source property name will be used.
+     * @param int|null                                                                                                 $maxDepth       The maximum depth of the mapping. If null, the default max depth will be used.
+     * @param string|callable(mixed $value, object|array<string, mixed> $source, array<string, mixed> $context): mixed $transformer    A transformer id or a callable that transform the value during mapping
+     * @param bool|null                                                                                                $ignore         If true, the property will be ignored during mapping
+     * @param string|null                                                                                              $if             The condition to map the property, using the expression language
+     * @param string[]|null                                                                                            $groups         The groups to map the property
+     * @param string|null                                                                                              $dateTimeFormat The date-time format to use when transforming this property
      */
     public function __construct(
         public string|array|null $target = null,


### PR DESCRIPTION
According to the `PropertyTransformerInterface`, the signature of a transformer should be: 

```php
/**
 * @param mixed                       $value   the value of the property to transform, can be null if there is no way to read the data from the mapping
 * @param object|array<string, mixed> $source  the source input on which the custom transformation applies
 * @param array<string, mixed>        $context Context during mapping
 */
public function transform(mixed $value, object|array $source, array $context): mixed;
```