### PR TITLE
Add support for phpstan/phpdoc-parser 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [GH#186](https://github.com/jolicode/automapper/pull/186) Optimize creation from constructor
+- [GH#205](https://github.com/jolicode/automapper/pull/205) Add support for phpstan/phpdoc-parser 2
 
 ### Fixed
 - [GH#184](https://github.com/jolicode/automapper/pull/184) Fix error when mapping from stdClass to constructor with nullable/optional arguments

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/lock": "^6.4 || ^7.0",
         "symfony/property-info": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
-        "phpdocumentor/type-resolver": "^1.7"
+        "phpdocumentor/type-resolver": "^1.7",
+        "phpstan/phpdoc-parser": "^1.13 || ^2.0"
     },
     "require-dev": {
         "api-platform/core": "^3.0.4",

--- a/src/Extractor/GetTypeTrait.php
+++ b/src/Extractor/GetTypeTrait.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 use Symfony\Component\PropertyInfo\PhpStan\NameScopeFactory;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\PropertyInfo\Util\PhpStanTypeHelper;
@@ -43,8 +44,20 @@ trait GetTypeTrait
             return null;
         }
 
-        static $phpDocParser = new PhpDocParser(new TypeParser(new ConstExprParser()), new ConstExprParser());
-        static $lexer = new Lexer();
+        static $phpDocParser = null;
+        static $lexer = null;
+
+        if ($phpDocParser === null || $lexer === null) {
+            if (class_exists(ParserConfig::class)) {
+                $config = new ParserConfig([]);
+                $phpDocParser = new PhpDocParser($config, new TypeParser($config, new ConstExprParser($config)), new ConstExprParser($config));
+                $lexer = new Lexer($config);
+            } else {
+                $phpDocParser = new PhpDocParser(new TypeParser(new ConstExprParser()), new ConstExprParser()); // @phpstan-ignore-line
+                $lexer = new Lexer(); // @phpstan-ignore-line
+            }
+        }
+
         static $nameScopeFactory = new NameScopeFactory();
         static $phpStanTypeHelper = new PhpStanTypeHelper();
 


### PR DESCRIPTION
I noticed locally that random test started to fail, turns out it's because [phpdocumentor/type-resolver added support for phpstan/phpdoc-parser v2](https://github.com/phpDocumentor/TypeResolver/releases/tag/1.10.0), but this library not ready for phpdoc-parser v2.
I chose minimal version of 1.13 because minimal version of [phpdocumentor/type-resolver required it](https://github.com/phpDocumentor/TypeResolver/blob/1.7.0/composer.json#L15) so there should be no changes to `composer update --prefer-lowest` 