### PR TITLE
fix: implicity nullable parameter deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [GH#207](https://github.com/jolicode/automapper/pull/207) Fix implicity nullable parameter deprecations
 
 ## [9.2.0] - 2024-11-19
 ### Added

--- a/src/Extractor/FromSourceMappingExtractor.php
+++ b/src/Extractor/FromSourceMappingExtractor.php
@@ -51,7 +51,7 @@ final class FromSourceMappingExtractor extends MappingExtractor
         return $types;
     }
 
-    private function transformType(string $target, Type $type = null): ?Type
+    private function transformType(string $target, ?Type $type = null): ?Type
     {
         if (null === $type) {
             return null;

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -326,8 +326,8 @@ final class MetadataFactory
         MetadataRegistry $metadataRegistry,
         ClassDiscriminatorResolver $classDiscriminatorResolver,
         array $transformerFactories = [],
-        ClassMetadataFactory $classMetadataFactory = null,
-        AdvancedNameConverterInterface $nameConverter = null,
+        ?ClassMetadataFactory $classMetadataFactory = null,
+        ?AdvancedNameConverterInterface $nameConverter = null,
         ExpressionLanguage $expressionLanguage = new ExpressionLanguage(),
         EventDispatcherInterface $eventDispatcher = new EventDispatcher(),
     ): self {

--- a/src/php-parser.php
+++ b/src/php-parser.php
@@ -37,7 +37,7 @@ function create_scalar_int(int $value, array $attributes = []): Scalar\Int_|Scal
  *
  * @internal
  */
-function create_expr_array_item(Expr $value, Expr $key = null, bool $byRef = false, array $attributes = [], bool $unpack = false): Node\ArrayItem|Expr\ArrayItem
+function create_expr_array_item(Expr $value, ?Expr $key = null, bool $byRef = false, array $attributes = [], bool $unpack = false): Node\ArrayItem|Expr\ArrayItem
 {
     $class = class_exists(Node\ArrayItem::class) ? Node\ArrayItem::class : Expr\ArrayItem::class;
 


### PR DESCRIPTION
Deprecated since PHP 8.4, see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types 