### PR TITLE
feat(extractor): remove default property mapping, if at least one attribute is set

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -147,6 +147,7 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
         ?ExpressionLanguageProvider $expressionLanguageProvider = null,
         EventDispatcherInterface $eventDispatcher = new EventDispatcher(),
         iterable $providers = [],
+        bool $removeDefaultProperties = false,
     ): AutoMapperInterface {
         if (\count($transformerFactories) > 0) {
             trigger_deprecation('jolicode/automapper', '9.0', 'The "$transformerFactories" property will be removed in version 10.0, AST transformer factories must be included within AutoMapper.', __METHOD__);
@@ -189,7 +190,8 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
             $classMetadataFactory,
             $nameConverter,
             $expressionLanguage,
-            $eventDispatcher
+            $eventDispatcher,
+            $removeDefaultProperties,
         );
 
         $mapperGenerator = new MapperGenerator(

--- a/src/Event/PropertyMetadataEvent.php
+++ b/src/Event/PropertyMetadataEvent.php
@@ -30,6 +30,7 @@ final class PropertyMetadataEvent
         public ?array $groups = null,
         public ?bool $disableGroupsCheck = null,
         public int $priority = 0,
+        public readonly bool $isFromDefaultExtractor = false,
     ) {
     }
 }

--- a/tests/AutoMapperBuilder.php
+++ b/tests/AutoMapperBuilder.php
@@ -28,6 +28,7 @@ class AutoMapperBuilder
         string $dateTimeFormat = \DateTimeInterface::RFC3339,
         ?ExpressionLanguageProvider $expressionLanguageProvider = null,
         EventDispatcherInterface $eventDispatcher = new EventDispatcher(),
+        bool $removeDefaultProperties = false,
     ): AutoMapper {
         $skipCacheRemove = $_SERVER['SKIP_CACHE_REMOVE'] ?? false;
 
@@ -52,6 +53,7 @@ class AutoMapperBuilder
             expressionLanguageProvider: $expressionLanguageProvider,
             eventDispatcher: $eventDispatcher,
             providers: $providers,
+            removeDefaultProperties: $removeDefaultProperties,
         );
     }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\Fixtures;
 
+use AutoMapper\Attribute\MapTo;
+
 class User
 {
     /**
      * @var int
      */
+    #[MapTo(target: 'array', property: '_id')]
     private $id;
 
     /**

--- a/tests/Normalizer/AutoMapperNormalizerTest.php
+++ b/tests/Normalizer/AutoMapperNormalizerTest.php
@@ -68,6 +68,26 @@ class AutoMapperNormalizerTest extends AutoMapperTestCase
         $normalized = $this->normalizer->normalize($object);
         self::assertIsArray($normalized);
         self::assertEquals($expected['id'], $normalized['id']);
+        self::assertEquals($expected['id'], $normalized['_id']);
+        self::assertEquals($expected['name'], $normalized['name']);
+        self::assertEquals($expected['age'], $normalized['age']);
+    }
+
+    public function testNormalizeNoDefaultProperties(): void
+    {
+        $object = new Fixtures\User(1, 'Jack', 37);
+        $expected = ['id' => 1, 'name' => 'Jack', 'age' => 37];
+
+        $normalizer = new AutoMapperNormalizer(AutoMapperBuilder::buildAutoMapper(
+            mapPrivatePropertiesAndMethod: true,
+            classPrefix: 'AutoMapperNoDefaultProperties_',
+            removeDefaultProperties: true
+        ));
+        $normalized = $normalizer->normalize($object);
+
+        self::assertIsArray($normalized);
+        self::assertArrayNotHasKey('id', $normalized);
+        self::assertEquals($expected['id'], $normalized['_id']);
         self::assertEquals($expected['name'], $normalized['name']);
         self::assertEquals($expected['age'], $normalized['age']);
     }


### PR DESCRIPTION
Fix https://github.com/jolicode/automapper/issues/238

This does not change the current behavior as it's a BC break for existing app, however it add a flag and deprecation notice that warn user that this behavior will change in the next major release.

I also use ignore : true so we can show why it's not mapped for the user