### PR TITLE
Update invalid syntax in configuration.md for constant

### DIFF
--- a/docs/bundle/configuration.md
+++ b/docs/bundle/configuration.md
@@ -10,7 +10,7 @@ Then configure the bundle to your needs, for example:
 automapper:
   class_prefix: "Symfony_Mapper_"
   constructor_strategy: 'auto'
-  date_time_format: !php/const:DateTimeInterface::RFC3339
+  date_time_format: !php/const DateTimeInterface::RFC3339
   check_attributes: true
   auto_register: true
   map_private_properties: true


### PR DESCRIPTION
Fix: 
![image](https://github.com/user-attachments/assets/a55d72d2-ee14-442e-96b9-93282e41d2ee)

https://symfony.com/blog/new-in-symfony-3-2-php-constants-in-yaml-files