### PR TITLE
feat(mapper): set deep populate to true if passing an existing value

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -103,9 +103,11 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface
         if (\is_object($target)) {
             $targetType = $target::class;
             $context[MapperContext::TARGET_TO_POPULATE] = $target;
+            $context[MapperContext::DEEP_TARGET_TO_POPULATE] ??= true;
         } elseif (\is_array($target)) {
             $targetType = 'array';
             $context[MapperContext::TARGET_TO_POPULATE] = $target;
+            $context[MapperContext::DEEP_TARGET_TO_POPULATE] ??= true;
         } elseif (\is_string($target)) {
             $targetType = $target;
         }

--- a/src/Transformer/AbstractArrayTransformer.php
+++ b/src/Transformer/AbstractArrayTransformer.php
@@ -36,13 +36,24 @@ abstract readonly class AbstractArrayTransformer implements TransformerInterface
         $baseAssign = new Expr\Array_();
 
         if ($propertyMapping->target->readAccessor !== null) {
+            $isDefined = $propertyMapping->target->readAccessor->getIsDefinedExpression(new Expr\Variable('result'));
+            $existingValue = $propertyMapping->target->readAccessor->getExpression(new Expr\Variable('result'));
+
+            if (null !== $isDefined) {
+                $existingValue = new Expr\Ternary(
+                    $isDefined,
+                    $existingValue,
+                    $baseAssign
+                );
+            }
+
             $baseAssign = new Expr\Ternary(
                 new Expr\BinaryOp\Coalesce(
                     new Expr\ArrayDimFetch(new Expr\Variable('context'), new Scalar\String_(MapperContext::DEEP_TARGET_TO_POPULATE)),
                     new Expr\ConstFetch(new Name('false'))
                 ),
-                $propertyMapping->target->readAccessor->getExpression(new Expr\Variable('result')),
-                new Expr\Array_()
+                $existingValue,
+                $baseAssign
             );
         }
 

--- a/src/Transformer/ArrayToDoctrineCollectionTransformer.php
+++ b/src/Transformer/ArrayToDoctrineCollectionTransformer.php
@@ -36,12 +36,23 @@ final class ArrayToDoctrineCollectionTransformer implements TransformerInterface
         $baseAssign = new Expr\New_(new Name(ArrayCollection::class));
 
         if ($propertyMapping->target->readAccessor !== null) {
+            $isDefined = $propertyMapping->target->readAccessor->getIsDefinedExpression(new Expr\Variable('result'));
+            $existingValue = $propertyMapping->target->readAccessor->getExpression(new Expr\Variable('result'));
+
+            if (null !== $isDefined) {
+                $existingValue = new Expr\Ternary(
+                    $isDefined,
+                    $existingValue,
+                    $baseAssign
+                );
+            }
+
             $baseAssign = new Expr\Ternary(
                 new Expr\BinaryOp\Coalesce(
                     new Expr\ArrayDimFetch(new Expr\Variable('context'), new Scalar\String_(MapperContext::DEEP_TARGET_TO_POPULATE)),
                     new Expr\ConstFetch(new Name('false'))
                 ),
-                $propertyMapping->target->readAccessor->getExpression(new Expr\Variable('result')),
+                $existingValue,
                 $baseAssign,
             );
         }

--- a/tests/AutoMapperTest/ArrayConsistency/map.php
+++ b/tests/AutoMapperTest/ArrayConsistency/map.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Tests\AutoMapperTest\ArrayConsistency;
 
+use AutoMapper\MapperContext;
 use AutoMapper\Tests\AutoMapperBuilder;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -102,11 +103,11 @@ return (function () {
     $toCollection->values->add(5);
     $toCollection->values->add(6);
 
-    yield 'to' => $autoMapper->map($from, $to);
+    yield 'to' => $autoMapper->map($from, $to, [MapperContext::DEEP_TARGET_TO_POPULATE => false]);
 
-    yield 'toAdder' => $autoMapper->map($from, $toAdder);
+    yield 'toAdder' => $autoMapper->map($from, $toAdder, [MapperContext::DEEP_TARGET_TO_POPULATE => false]);
 
-    yield 'toAdderCollection' => $autoMapper->map($from, $toAdderCollection);
+    yield 'toAdderCollection' => $autoMapper->map($from, $toAdderCollection, [MapperContext::DEEP_TARGET_TO_POPULATE => false]);
 
-    yield 'toCollection' => $autoMapper->map($from, $toCollection);
+    yield 'toCollection' => $autoMapper->map($from, $toCollection, [MapperContext::DEEP_TARGET_TO_POPULATE => false]);
 })();


### PR DESCRIPTION
I think having this to true by default if we pass an existing value is better for DX, i kind of expect that by default when passing a value (having to set this value should be only opt out)