### PR TITLE
fix(constructor): fixed circular references with promoted properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [GH#272](https://github.com/jolicode/automapper/pull/272) Fixed circular references with promoted properties 
 
 ## [9.4.1] - 2025-06-03
 ### Fixed

--- a/tests/AutoMapperTest.php
+++ b/tests/AutoMapperTest.php
@@ -20,6 +20,8 @@ use AutoMapper\Tests\Fixtures\AddressDTOWithReadonly;
 use AutoMapper\Tests\Fixtures\AddressDTOWithReadonlyPromotedProperty;
 use AutoMapper\Tests\Fixtures\AddressType;
 use AutoMapper\Tests\Fixtures\AddressWithEnum;
+use AutoMapper\Tests\Fixtures\Category;
+use AutoMapper\Tests\Fixtures\CategoryDTO;
 use AutoMapper\Tests\Fixtures\ClassWithMapToContextAttribute;
 use AutoMapper\Tests\Fixtures\ClassWithNullablePropertyInConstructor;
 use AutoMapper\Tests\Fixtures\ClassWithPrivateProperty;
@@ -40,6 +42,7 @@ use AutoMapper\Tests\Fixtures\ObjectWithDateTime;
 use AutoMapper\Tests\Fixtures\Order;
 use AutoMapper\Tests\Fixtures\PetOwner;
 use AutoMapper\Tests\Fixtures\PetOwnerWithConstructorArguments;
+use AutoMapper\Tests\Fixtures\Post;
 use AutoMapper\Tests\Fixtures\SourceForConstructorWithDefaultValues;
 use AutoMapper\Tests\Fixtures\Transformer\MoneyTransformerFactory;
 use AutoMapper\Tests\Fixtures\Uninitialized;
@@ -1374,6 +1377,19 @@ class AutoMapperTest extends AutoMapperTestCase
 
             $this->assertSame($expected, $dump, sprintf('The dump of the map file "%s" is not as expected.', $key));
         }
+    }
+
+    public function testCircularReferenceForPromotedProperties(): void
+    {
+        $category = new Category('Category');
+        $category->posts[] = new Post('Example', $category);
+
+        $categoryDTO = $this->autoMapper->map($category, CategoryDTO::class);
+
+        self::assertEquals('Category', $categoryDTO->name);
+        self::assertCount(1, $categoryDTO->posts);
+        self::assertEquals('Example', $categoryDTO->posts[0]->name);
+        self::assertEquals($categoryDTO, $categoryDTO->posts[0]->category);
     }
 
     public static function provideAutoMapperFixturesTests(): iterable

--- a/tests/Fixtures/Category.php
+++ b/tests/Fixtures/Category.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+class Category
+{
+    /** @var Post[] */
+    public array $posts = [];
+
+    public function __construct(
+        public string $name
+    ) {
+    }
+}

--- a/tests/Fixtures/CategoryDTO.php
+++ b/tests/Fixtures/CategoryDTO.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+class CategoryDTO
+{
+    /**
+     * @var PostDTO[]
+     */
+    public array $posts = [];
+
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Fixtures/Post.php
+++ b/tests/Fixtures/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+class Post
+{
+    public function __construct(
+        public string $name,
+        public Category $category
+    ) {
+    }
+}

--- a/tests/Fixtures/PostDTO.php
+++ b/tests/Fixtures/PostDTO.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\Fixtures;
+
+class PostDTO
+{
+    public function __construct(
+        public string $name,
+        public CategoryDTO $category,
+    ) {
+    }
+}


### PR DESCRIPTION
Updates the generated mapper code such that circular references are handled properly when using promoted properties.

Solves #271