### PR TITLE
Fix support for symfony/property-info 7.3@beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [GH#274](https://github.com/jolicode/automapper/pull/274) Fix support for Symfony 7.3
+
 ### Added
 - [GH#246](https://github.com/jolicode/automapper/pull/246) Add support for PHP 8.4
 - [GH#246](https://github.com/jolicode/automapper/pull/246) Add support for API Platform 4


### PR DESCRIPTION
To test it, I forced 7.3@beta in the `composer.json`. But I didn't commit it!

```
>…re/dev/github.com/jolicode/automapper(sf7-3 *) composer show symfony/property-info
name     : symfony/property-info
descrip. : Extracts information about PHP class' properties using metadata of popular sources
keywords : doctrine, phpdoc, property, symfony, type, validator
versions : * v7.3.0-BETA1
released : 2025-04-04, 3 weeks ago
type     : library
license  : MIT License (MIT) (OSI approved) https://spdx.org/licenses/MIT.html#licenseText
homepage : https://symfony.com
source   : [git] https://github.com/symfony/property-info.git 200d230d8553610ada73ac557501dc4609aad31f
dist     : [zip] https://api.github.com/repos/symfony/property-info/zipball/200d230d8553610ada73ac557501dc4609aad31f 200d230d8553610ada73ac557501dc4609aad31f
path     : /home/gregoire/dev/github.com/jolicode/automapper/vendor/symfony/property-info
names    : symfony/property-info

support
source : https://github.com/symfony/property-info/tree/v7.3.0-BETA1

autoload
psr-4
Symfony\Component\PropertyInfo\ => .
exclude-from-classmap

requires
php >=8.2
symfony/deprecation-contracts ^2.5|^3
symfony/string ^6.4|^7.0
symfony/type-info ~7.1.9|^7.2.2

requires (dev)
phpdocumentor/reflection-docblock ^5.2
phpstan/phpdoc-parser ^1.0|^2.0
symfony/cache ^6.4|^7.0
symfony/dependency-injection ^6.4|^7.0
symfony/serializer ^6.4|^7.0

conflicts
phpdocumentor/reflection-docblock <5.2
phpdocumentor/type-resolver <1.5.1
symfony/cache <6.4
symfony/dependency-injection <6.4
symfony/serializer <6.4
>…re/dev/github.com/jolicode/automapper(sf7-3 *) ./vendor/bin/phpunit 
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

...............................................................  63 / 342 ( 18%)
............................................................... 126 / 342 ( 36%)
.........................................S..................... 189 / 342 ( 55%)
..........................................SSSSSSSSSSSSSSSSSSSSS 252 / 342 ( 73%)
......S.......S.....SS......................................... 315 / 342 ( 92%)
...........................                                     342 / 342 (100%)

Time: 00:04.116, Memory: 38.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 342, Assertions: 1013, Skipped: 26.
```
