### PR TITLE
fix mapping array of enums to setter which expects array of enums

### DIFF
--- a/src/Extractor/WriteMutator.php
+++ b/src/Extractor/WriteMutator.php
@@ -161,7 +161,7 @@ final class WriteMutator
                     $reflectionMethod->getDocComment(),
                     $target,
                     $reflectionMethod->getDeclaringClass()->getName(),
-                    $this->property,
+                    $reflectionMethod->getParameters()[0]->name,
                     '@param'
                 )) {
                     return $types;

--- a/tests/AutoMapperTest/Issue269/expected.data
+++ b/tests/AutoMapperTest/Issue269/expected.data
@@ -1,0 +1,8 @@
+AutoMapper\Tests\AutoMapperTest\Issue269\Entity {
+  -paymentMethods: [
+    AutoMapper\Tests\AutoMapperTest\Issue269\PaymentMethod {
+      +name: "First"
+      +value: "First"
+    }
+  ]
+}

--- a/tests/AutoMapperTest/Issue269/map.php
+++ b/tests/AutoMapperTest/Issue269/map.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\Issue269;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+enum PaymentMethod: string
+{
+    case First = 'First';
+}
+
+class Dto
+{
+    /** @var PaymentMethod[] */
+    public ?array $paymentMethods = null;
+}
+
+class Entity
+{
+    /** @var PaymentMethod[] */
+    private array $paymentMethods = [];
+
+    /** @param PaymentMethod[] $paymentMethods */
+    public function setPaymentMethods(array $paymentMethods): self
+    {
+        $this->paymentMethods = $paymentMethods;
+
+        return $this;
+    }
+
+    /** @return PaymentMethod[] */
+    public function getPaymentMethods(): array
+    {
+        return $this->paymentMethods;
+    }
+}
+
+$dto = new Dto();
+$dto->paymentMethods = [PaymentMethod::First];
+
+return AutoMapperBuilder::buildAutoMapper()->map($dto, Entity::class);


### PR DESCRIPTION
Closes #269
I found out that this bug was introduced in #230, to be more precise this lines [ArrayTransformerFactory](https://github.com/jolicode/automapper/blob/9.4.1/src/Transformer/ArrayTransformerFactory.php#L42-L45).
Before #230 `$targetCollections` would be equal `[]` so we would get  `return new DictionaryTransformer(new CopyTransformer());`. And CopyTransformer would just pass enums from property to `setPaymentMethods()`.
But simply removing this lines wouldn't work because they do serve they purpose in fixing weird behavior in #230.

So I dug further and found out original issue.
Here [WriteMutator](https://github.com/jolicode/automapper/blob/9.4.1/src/Extractor/WriteMutator.php#L160-L165) should get that `setPaymentMethods()` expects `PaymentMethod[]` but gets blocked here [GetTypeTrait](https://github.com/jolicode/automapper/blob/9.4.1/src/Extractor/GetTypeTrait.php#L81) because argument `$property` equals `'setPaymentMethods'` and we get this check that result in false and we skip trying to extract types
```php
'$paymentMethods' !== '$setPaymentMethods'
```