### PR TITLE
Optimize condition order to avoid unnecessary method calls in AutoMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.4.2] - 2025-07-17
+### Changed
+- [GH#286](https://github.com/jolicode/automapper/pull/286) Optimize condition order to avoid unnecessary method calls by prioritizing custom conditions
+
 ## [Unreleased]
 ### Fixed
 - [GH#272](https://github.com/jolicode/automapper/pull/272) Fixed circular references with promoted properties 

--- a/src/Generator/PropertyConditionsGenerator.php
+++ b/src/Generator/PropertyConditionsGenerator.php
@@ -40,6 +40,7 @@ final readonly class PropertyConditionsGenerator
     {
         $conditions = [];
 
+        $conditions[] = $this->customCondition($metadata, $propertyMetadata);
         $conditions[] = $this->propertyExistsForStdClass($metadata, $propertyMetadata);
         $conditions[] = $this->propertyExistsForArray($metadata, $propertyMetadata);
 
@@ -59,8 +60,6 @@ final readonly class PropertyConditionsGenerator
 
             $conditions[] = $this->maxDepthCheck($metadata, $propertyMetadata);
         }
-
-        $conditions[] = $this->customCondition($metadata, $propertyMetadata);
 
         $conditions = array_values(array_filter($conditions));
 


### PR DESCRIPTION
This PR reorders the generated condition checks in the generate() method to prioritize the customCondition() check before other standard conditions.

In the generated mapper code, this change allows custom condition to occur earlier. As a result, potentially heavy methods, such as those that may trigger database queries are not executed if the custom condition fails.

Before:
```php
if (isAllowedAttribute(...) && groupsCheck(...) && customCondition(...)) { // DB hit
   $result->someProperty = $value->someMethod(); // DB hit
}
```

After:
```php
if (customCondition(...) && isAllowedAttribute(...) && groupsCheck(...)) {
    $result->someProperty = $value->someMethod(); // DB hit only if needed
}
```