### PR TITLE
fix(transformer): cast inner values of array properties when mapping from untyped sources

### DIFF
--- a/src/Transformer/ArrayTransformerFactory.php
+++ b/src/Transformer/ArrayTransformerFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AutoMapper\Transformer;
 
+use AutoMapper\Lazy\LazyMap;
 use AutoMapper\Metadata\MapperMetadata;
 use AutoMapper\Metadata\SourcePropertyMetadata;
 use AutoMapper\Metadata\TargetPropertyMetadata;
@@ -37,10 +38,23 @@ final class ArrayTransformerFactory implements TransformerFactoryInterface, Prio
         $sourceCollectionType = $sourceType instanceof Type\CollectionType ? $sourceType->getCollectionValueType() : Type::mixed();
         $targetCollectionType = $targetType instanceof Type\CollectionType ? $targetType->getCollectionValueType() : Type::mixed();
 
+        // For untyped sources, the value type is mirrored from target and needs
+        // overriding to mixed so the chain generates proper scalar casts.
+        $wrapWithNullable = false;
+        if (isset($mapperMetadata->source)
+            && \in_array($mapperMetadata->source, ['array', \stdClass::class, LazyMap::class], true)) {
+            [$sourceCollectionType, $wrapWithNullable] = $this->overrideSourceCollectionType($sourceCollectionType, $targetCollectionType);
+        }
+
         $newSource = $source->withType($sourceCollectionType);
-        $newTarget = $target->withType($targetCollectionType);
+        $newTarget = $target->withType($wrapWithNullable && $targetCollectionType instanceof Type\NullableType ? $targetCollectionType->getWrappedType() : $targetCollectionType);
 
         $subItemTransformer = $this->chainTransformerFactory->getTransformer($newSource, $newTarget, $mapperMetadata);
+
+        // NullableType(mixed) is impossible in TypeInfo, so we wrap manually.
+        if (null !== $subItemTransformer && $wrapWithNullable) {
+            $subItemTransformer = new NullableTransformer($subItemTransformer, $targetCollectionType->isNullable());
+        }
 
         if (null !== $subItemTransformer) {
             if ($subItemTransformer instanceof ObjectTransformer) {
@@ -57,6 +71,30 @@ final class ArrayTransformerFactory implements TransformerFactoryInterface, Prio
         }
 
         return null;
+    }
+
+    /**
+     * @return array{Type, bool} Overridden source type and whether to wrap with NullableTransformer
+     */
+    private function overrideSourceCollectionType(Type $sourceCollectionType, Type $targetCollectionType): array
+    {
+        if ($sourceCollectionType instanceof Type\NullableType) {
+            $isNullable = true;
+            $unwrappedSource = $sourceCollectionType->getWrappedType();
+        } else {
+            $isNullable = false;
+            $unwrappedSource = $sourceCollectionType;
+        }
+        $unwrappedTarget = $targetCollectionType instanceof Type\NullableType ? $targetCollectionType->getWrappedType() : $targetCollectionType;
+
+        if ($unwrappedSource instanceof Type\BuiltinType
+            && $unwrappedTarget instanceof Type\BuiltinType
+            && $unwrappedSource->getTypeIdentifier() === $unwrappedTarget->getTypeIdentifier()
+            && $unwrappedSource->getTypeIdentifier() !== TypeIdentifier::MIXED) {
+            return [Type::mixed(), $isNullable];
+        }
+
+        return [$sourceCollectionType, false];
     }
 
     private function isCollectionType(Type $type): bool

--- a/src/Transformer/BuiltinTransformer.php
+++ b/src/Transformer/BuiltinTransformer.php
@@ -36,6 +36,7 @@ final readonly class BuiltinTransformer implements TransformerInterface, CheckTy
             TypeIdentifier::INT->value => Cast\Int_::class,
             TypeIdentifier::STRING->value => Cast\String_::class,
             TypeIdentifier::FLOAT->value => 'toFloat',
+            TypeIdentifier::BOOL->value => Cast\Bool_::class,
             TypeIdentifier::ARRAY->value => 'toArray',
             TypeIdentifier::ITERABLE->value => 'toArray',
         ],

--- a/tests/AutoMapperTest/ArraySourceCastAlreadyCorrect/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastAlreadyCorrect/expected.data
@@ -1,0 +1,11 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastAlreadyCorrect\Dto {
+  +ids: [
+    1
+    2
+    3
+  ]
+  +names: [
+    "Alice"
+    "Bob"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastAlreadyCorrect/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastAlreadyCorrect/map.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastAlreadyCorrect;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array<int> */
+    public array $ids;
+
+    /** @var array<string> */
+    public array $names;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    // Values already match target types — should pass through without issues
+    yield $autoMapper->map([
+        'ids' => [1, 2, 3],
+        'names' => ['Alice', 'Bob'],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastDateTime/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastDateTime/expected.data
@@ -1,0 +1,10 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastDateTime\Dto {
+  +dates: [
+    DateTimeImmutable @1705314600 {
+      date: 2024-01-15 10:30:00.0 +00:00
+    }
+    DateTimeImmutable @1718892000 {
+      date: 2024-06-20 14:00:00.0 +00:00
+    }
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastDateTime/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastDateTime/map.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastDateTime;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array<\DateTimeImmutable> */
+    public array $dates;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'dates' => ['2024-01-15T10:30:00+00:00', '2024-06-20T14:00:00+00:00'],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastDictionary/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastDictionary/expected.data
@@ -1,0 +1,10 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastDictionary\Dto {
+  +scores: [
+    "alice" => 100
+    "bob" => 85
+  ]
+  +rates: [
+    "usd" => 1.0
+    "eur" => 0.92
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastDictionary/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastDictionary/map.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastDictionary;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array<string, int> */
+    public array $scores;
+
+    /** @var array<string, float> */
+    public array $rates;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'scores' => ['alice' => '100', 'bob' => '85'],
+        'rates' => ['usd' => '1.0', 'eur' => '0.92'],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastInnerValues/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastInnerValues/expected.data
@@ -1,0 +1,22 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastInnerValues\Dto {
+  +ids: [
+    1
+    2
+    3
+  ]
+  +prices: [
+    9.99
+    19.99
+  ]
+  +labels: [
+    "1"
+    "2"
+    "3"
+  ]
+  +flags: [
+    true
+    false
+    true
+    false
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastInnerValues/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastInnerValues/map.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastInnerValues;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array<int> */
+    public array $ids;
+
+    /** @var array<float> */
+    public array $prices;
+
+    /** @var array<string> */
+    public array $labels;
+
+    /** @var array<bool> */
+    public array $flags;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'ids' => ['1', '2', '3'],
+        'prices' => ['9.99', '19.99'],
+        'labels' => [1, 2, 3],
+        'flags' => [1, 0, '1', ''],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastNested/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastNested/expected.data
@@ -1,0 +1,12 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastNested\Dto {
+  +matrix: [
+    [
+      1
+      2
+    ]
+    [
+      3
+      4
+    ]
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastNested/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastNested/map.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastNested;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array<array<int>> */
+    public array $matrix;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'matrix' => [['1', '2'], ['3', '4']],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastNullable/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastNullable/expected.data
@@ -1,0 +1,7 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastNullable\Dto {
+  +values: [
+    1
+    null
+    3
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastNullable/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastNullable/map.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastNullable;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array<int|null> */
+    public array $values;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'values' => ['1', null, '3'],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastObjects/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastObjects/expected.data
@@ -1,0 +1,12 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastObjects\ContainerDto {
+  +items: [
+    AutoMapper\Tests\AutoMapperTest\ArraySourceCastObjects\ItemDto {
+      +id: 1
+      +name: "First"
+    }
+    AutoMapper\Tests\AutoMapperTest\ArraySourceCastObjects\ItemDto {
+      +id: 2
+      +name: "Second"
+    }
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastObjects/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastObjects/map.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastObjects;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class ItemDto
+{
+    public int $id;
+    public string $name;
+}
+
+class ContainerDto
+{
+    /** @var array<ItemDto> */
+    public array $items;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'items' => [
+            ['id' => '1', 'name' => 'First'],
+            ['id' => '2', 'name' => 'Second'],
+        ],
+    ], ContainerDto::class);
+})();


### PR DESCRIPTION
Hi @joelwurtz, 

I finally got the chance to test the feature addressing [my original issue](https://github.com/jolicode/automapper/issues/195). Works great using attributes, thanks again!. However, I just wondered if that could be done using phpdoc only. Because having to leverage attributes feels a bit redundant for those use cases:

```php
 // $source: ['10', '12.5']

 /** @var array<float> */
 public array $age;
```

`FromTargetMappingExtractor::transformTargetType()` mirrors target types to source for untyped sources (array, stdClass, LazyMap). For `array<int>`, the source value type becomes `int` - identical to target. `BuiltinTransformer(int,
int)` sees matching types and returns input unchanged, skipping the cast.

### Solution

In `ArrayTransformerFactory`, detect when source is untyped and the collection value types are identical mirrored scalars, then override the source value type to `mixed`. This makes the chain resolve to `BuiltinTransformer(mixed,
target_type)` which generates explicit casts.

Nullable types (`array<int|null>`) are handled via manual `NullableTransformer` wrapping since `NullableType(mixed)` is impossible in Symfony TypeInfo.

Also adds the missing `bool` entry in `BuiltinTransformer::CAST_MAPPING[mixed]`.

Let me know if this needs change. 