### PR TITLE
[Docs] Fix syntax error in supports method return statement

### DIFF
--- a/docs/mapping/transformer.md
+++ b/docs/mapping/transformer.md
@@ -136,7 +136,7 @@ class UrlTransformer implements PropertyTransformerSupportInterface
     
     public function supports(SourcePropertyMetadata $source, TargetPropertyMetadata $target, MapperMetadata $mapperMetadata): bool
     {
-        return $source->type->isIdentifiedBy(TypeIdentifier::INT && $source->property === 'id' && $target->property === 'url';
+        return $source->type->isIdentifiedBy(TypeIdentifier::INT) && $source->property === 'id' && $target->property === 'url';
     }
     
     public function transform(mixed $value, object|array $source, array $context): mixed
@@ -191,7 +191,7 @@ class UrlTransformer implements PropertyTransformerComputeInterface
     
     public function supports(SourcePropertyMetadata $source, TargetPropertyMetadata $target, MapperMetadata $mapperMetadata): bool
     {
-        return $source->type->isIdentifiedBy(TypeIdentifier::INT && $source->property === 'id' && $target->property === 'url';
+        return $source->type->isIdentifiedBy(TypeIdentifier::INT) && $source->property === 'id' && $target->property === 'url';
     }
 
     public function compute(SourcePropertyMetadata $source, TargetPropertyMetadata $target, MapperMetadata $mapperMetadata): mixed


### PR DESCRIPTION
Hi there!

I'm looking into this package as I need to map objects in a recent project, and realised this small issue in the Transformers docs so thought I would submit a quick patch,

Thanks for the amazing work done here! 