### PR TITLE
Fix psalm incompatibility with class-string<object> notation

### DIFF
--- a/src/Metadata/Discriminator.php
+++ b/src/Metadata/Discriminator.php
@@ -7,7 +7,7 @@ namespace AutoMapper\Metadata;
 final readonly class Discriminator
 {
     public function __construct(
-        /** @var array<string, class-string<object>> */
+        /** @var array<string, class-string> */
         public array $mapping,
         public ?string $propertyName = null,
     ) {


### PR DESCRIPTION
## Problem

Psalm 6 crashes with an uncaught `DocblockParseException` when scanning 
`src/Metadata/Discriminator.php` due to the `class-string<object>` type 
in the docblock:
```
Uncaught Psalm\Exception\DocblockParseException: array<string, class-string<object>> 
is not a valid type (class-string param can only target to named or callable objects)
```

This crash occurs during autoload scanning, before analysis even starts, 
making it impossible to use Psalm on projects that depend on AutoMapper.

**Versions affected:**
- AutoMapper: `10.0.3`
- Psalm: `6.15.1`

## Fix

Replace `class-string<object>` with `class-string` in the `Discriminator` 
constructor docblock.

Since every PHP class implicitly extends `object`, these two types are 
strictly equivalent — no type safety is lost.
