### PR TITLE
feat(transformer): add ArrayShapeTransformer and support for array shape

### DIFF
--- a/src/Extractor/FromTargetMappingExtractor.php
+++ b/src/Extractor/FromTargetMappingExtractor.php
@@ -92,6 +92,23 @@ final class FromTargetMappingExtractor extends MappingExtractor
             return new Type\IntersectionType(...$types);
         }
 
+        if ($type instanceof Type\ArrayShapeType) {
+            $transformedShape = [];
+            foreach ($type->getShape() as $key => $field) {
+                $transformedType = $this->transformTargetType($source, $field['type']);
+                $transformedShape[$key] = [
+                    'type' => $transformedType ?? Type::mixed(),
+                    'optional' => $field['optional'],
+                ];
+            }
+
+            return new Type\ArrayShapeType(
+                $transformedShape,
+                $type->getExtraKeyType(),
+                $type->getExtraValueType(),
+            );
+        }
+
         if ($type instanceof Type\CollectionType) {
             $keyType = $this->transformTargetType($source, $type->getCollectionKeyType());
             $valueType = $this->transformTargetType($source, $type->getCollectionValueType());

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -30,6 +30,7 @@ use AutoMapper\Extractor\SourceTargetMappingExtractor;
 use AutoMapper\Generator\Shared\ClassDiscriminatorResolver;
 use AutoMapper\Lazy\LazyMap;
 use AutoMapper\Transformer\AllowNullValueTransformerInterface;
+use AutoMapper\Transformer\ArrayShapeTransformerFactory;
 use AutoMapper\Transformer\ArrayTransformerFactory;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;
@@ -406,6 +407,7 @@ final class MetadataFactory
             new UniqueTypeTransformerFactory(),
             new DateTimeTransformerFactory(),
             new BuiltinTransformerFactory(),
+            new ArrayShapeTransformerFactory(),
             new ArrayTransformerFactory(),
             new ObjectTransformerFactory(),
             new EnumTransformerFactory(),

--- a/src/Symfony/Bundle/Resources/config/transformers.php
+++ b/src/Symfony/Bundle/Resources/config/transformers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use AutoMapper\Transformer\ArrayShapeTransformerFactory;
 use AutoMapper\Transformer\ArrayTransformerFactory;
 use AutoMapper\Transformer\BuiltinTransformerFactory;
 use AutoMapper\Transformer\ChainTransformerFactory;
@@ -49,8 +50,11 @@ return static function (ContainerConfigurator $container) {
         ->set(BuiltinTransformerFactory::class)
             ->tag('automapper.transformer_factory', ['priority' => -1001])
 
-        ->set(ArrayTransformerFactory::class)
+        ->set(ArrayShapeTransformerFactory::class)
             ->tag('automapper.transformer_factory', ['priority' => -1002])
+
+        ->set(ArrayTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => -1003])
 
         ->set(ObjectTransformerFactory::class)
             ->tag('automapper.transformer_factory', ['priority' => -1004])

--- a/src/Transformer/ArrayShapeTransformer.php
+++ b/src/Transformer/ArrayShapeTransformer.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Transformer;
+
+use AutoMapper\Generator\UniqueVariableScope;
+use AutoMapper\Metadata\PropertyMetadata;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+
+/**
+ * Transformer for array shape types (array{key: type, ...}).
+ *
+ * Applies per-key sub-transformers instead of a uniform loop.
+ *
+ * @internal
+ */
+final readonly class ArrayShapeTransformer implements \Stringable, TransformerInterface, DependentTransformerInterface
+{
+    /**
+     * @param array<string|int, array{transformer: TransformerInterface, optional: bool}> $fieldTransformers
+     */
+    public function __construct(
+        private array $fieldTransformers,
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMetadata $propertyMapping, UniqueVariableScope $uniqueVariableScope, Expr $source, ?Expr $existingValue = null): array
+    {
+        $valuesVar = new Expr\Variable($uniqueVariableScope->getUniqueName('values'));
+
+        $statements = [
+            new Stmt\Expression(new Expr\Assign($valuesVar, new Expr\Array_())),
+        ];
+
+        foreach ($this->fieldTransformers as $key => $field) {
+            $keyExpr = \is_int($key) ? new Scalar\Int_($key) : new Scalar\String_($key);
+            $fieldInput = new Expr\ArrayDimFetch($input, $keyExpr);
+
+            [$fieldOutput, $fieldStatements] = $field['transformer']->transform(
+                $fieldInput,
+                $target,
+                $propertyMapping,
+                $uniqueVariableScope,
+                $source,
+                null,
+            );
+
+            $assignStmt = new Stmt\Expression(
+                new Expr\Assign(new Expr\ArrayDimFetch($valuesVar, $keyExpr), $fieldOutput)
+            );
+            $fieldStatements[] = $assignStmt;
+
+            if ($field['optional']) {
+                $statements[] = new Stmt\If_(
+                    new Expr\FuncCall(new Name('array_key_exists'), [
+                        new Arg($keyExpr),
+                        new Arg($input),
+                    ]),
+                    ['stmts' => $fieldStatements],
+                );
+            } else {
+                array_push($statements, ...$fieldStatements);
+            }
+        }
+
+        return [$valuesVar, $statements];
+    }
+
+    public function getDependencies(): array
+    {
+        $dependencies = [];
+
+        foreach ($this->fieldTransformers as $field) {
+            if ($field['transformer'] instanceof DependentTransformerInterface) {
+                array_push($dependencies, ...$field['transformer']->getDependencies());
+            }
+        }
+
+        return $dependencies;
+    }
+
+    public function __toString(): string
+    {
+        $fields = [];
+        foreach ($this->fieldTransformers as $key => $field) {
+            $transformerName = $field['transformer'] instanceof \Stringable
+                ? (string) $field['transformer']
+                : \get_class($field['transformer']);
+            $fields[] = \sprintf('%s: %s', $key, $transformerName);
+        }
+
+        return \sprintf('ArrayShapeTransformer{%s}', implode(', ', $fields));
+    }
+}

--- a/src/Transformer/ArrayShapeTransformerFactory.php
+++ b/src/Transformer/ArrayShapeTransformerFactory.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Transformer;
+
+use AutoMapper\Lazy\LazyMap;
+use AutoMapper\Metadata\MapperMetadata;
+use AutoMapper\Metadata\SourcePropertyMetadata;
+use AutoMapper\Metadata\TargetPropertyMetadata;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Create a transformer to handle array shape types (array{key: type, ...}).
+ *
+ * Applies per-key sub-transformers instead of a uniform loop.
+ *
+ * @internal
+ */
+final class ArrayShapeTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface, ChainTransformerFactoryAwareInterface
+{
+    use ChainTransformerFactoryAwareTrait;
+
+    public function getTransformer(SourcePropertyMetadata $source, TargetPropertyMetadata $target, MapperMetadata $mapperMetadata): ?TransformerInterface
+    {
+        $sourceType = $source->type;
+        $targetType = $target->type;
+
+        if (null === $sourceType || null === $targetType) {
+            return null;
+        }
+
+        if (!$targetType instanceof Type\ArrayShapeType || [] === $targetType->getShape()) {
+            return null;
+        }
+
+        $fieldTransformers = [];
+        $sourceIsUntyped = isset($mapperMetadata->source)
+            && \in_array($mapperMetadata->source, ['array', \stdClass::class, LazyMap::class], true);
+
+        $sourceShape = $sourceType instanceof Type\ArrayShapeType ? $sourceType->getShape() : [];
+
+        foreach ($targetType->getShape() as $key => $field) {
+            $fieldTargetType = $field['type'];
+
+            if ($sourceIsUntyped) {
+                $fieldSourceType = $sourceShape[$key]['type'] ?? Type::mixed();
+                [$fieldSourceType] = $this->overrideSourceCollectionType($fieldSourceType, $fieldTargetType);
+            } else {
+                $fieldSourceType = $sourceShape[$key]['type'] ?? $fieldTargetType;
+            }
+
+            $newSource = $source->withType($fieldSourceType);
+            $newTarget = $target->withType($fieldTargetType);
+
+            $fieldTransformer = $this->chainTransformerFactory->getTransformer($newSource, $newTarget, $mapperMetadata);
+
+            if (null === $fieldTransformer) {
+                return null;
+            }
+
+            $fieldTransformers[$key] = [
+                'transformer' => $fieldTransformer,
+                'optional' => $field['optional'],
+            ];
+        }
+
+        return new ArrayShapeTransformer($fieldTransformers);
+    }
+
+    /**
+     * @return array{Type, bool} Overridden source type and whether to wrap with NullableTransformer
+     */
+    private function overrideSourceCollectionType(Type $sourceCollectionType, Type $targetCollectionType): array
+    {
+        if ($sourceCollectionType instanceof Type\NullableType) {
+            $isNullable = true;
+            $unwrappedSource = $sourceCollectionType->getWrappedType();
+        } else {
+            $isNullable = false;
+            $unwrappedSource = $sourceCollectionType;
+        }
+        $unwrappedTarget = $targetCollectionType instanceof Type\NullableType ? $targetCollectionType->getWrappedType() : $targetCollectionType;
+
+        if ($unwrappedSource instanceof Type\BuiltinType
+            && $unwrappedTarget instanceof Type\BuiltinType
+            && $unwrappedSource->getTypeIdentifier() === $unwrappedTarget->getTypeIdentifier()
+            && $unwrappedSource->getTypeIdentifier() !== TypeIdentifier::MIXED) {
+            return [Type::mixed(), $isNullable];
+        }
+
+        return [$sourceCollectionType, false];
+    }
+
+    public function getPriority(): int
+    {
+        return 5;
+    }
+}

--- a/src/Transformer/ArrayTransformerFactory.php
+++ b/src/Transformer/ArrayTransformerFactory.php
@@ -48,7 +48,7 @@ final class ArrayTransformerFactory implements TransformerFactoryInterface, Prio
                     $fieldSourceType = $sourceShape[$key]['type'] ?? Type::mixed();
                     [$fieldSourceType] = $this->overrideSourceCollectionType($fieldSourceType, $fieldTargetType);
                 } else {
-                    $fieldSourceType = $fieldTargetType;
+                    $fieldSourceType = $sourceShape[$key]['type'] ?? $fieldTargetType;
                 }
 
                 $newSource = $source->withType($fieldSourceType);

--- a/src/Transformer/ArrayTransformerFactory.php
+++ b/src/Transformer/ArrayTransformerFactory.php
@@ -31,44 +31,6 @@ final class ArrayTransformerFactory implements TransformerFactoryInterface, Prio
             return null;
         }
 
-        // Handle array shape types — per-key transformers (skip empty shapes from object mapping)
-        if ($targetType instanceof Type\ArrayShapeType && [] !== $targetType->getShape()) {
-            $fieldTransformers = [];
-            $sourceIsUntyped = isset($mapperMetadata->source)
-                && \in_array($mapperMetadata->source, ['array', \stdClass::class, LazyMap::class], true);
-
-            $sourceShape = $sourceType instanceof Type\ArrayShapeType ? $sourceType->getShape() : [];
-
-            foreach ($targetType->getShape() as $key => $field) {
-                $fieldTargetType = $field['type'];
-
-                if ($sourceIsUntyped) {
-                    // Use the mirrored source type from FromTargetMappingExtractor,
-                    // then override to mixed only for matching builtins (to force casts).
-                    $fieldSourceType = $sourceShape[$key]['type'] ?? Type::mixed();
-                    [$fieldSourceType] = $this->overrideSourceCollectionType($fieldSourceType, $fieldTargetType);
-                } else {
-                    $fieldSourceType = $sourceShape[$key]['type'] ?? $fieldTargetType;
-                }
-
-                $newSource = $source->withType($fieldSourceType);
-                $newTarget = $target->withType($fieldTargetType);
-
-                $fieldTransformer = $this->chainTransformerFactory->getTransformer($newSource, $newTarget, $mapperMetadata);
-
-                if (null === $fieldTransformer) {
-                    return null;
-                }
-
-                $fieldTransformers[$key] = [
-                    'transformer' => $fieldTransformer,
-                    'optional' => $field['optional'],
-                ];
-            }
-
-            return new ArrayShapeTransformer($fieldTransformers);
-        }
-
         if (!$this->isCollectionType($sourceType) || !$this->isCollectionType($targetType)) {
             return null;
         }

--- a/src/Transformer/ArrayTransformerFactory.php
+++ b/src/Transformer/ArrayTransformerFactory.php
@@ -31,6 +31,44 @@ final class ArrayTransformerFactory implements TransformerFactoryInterface, Prio
             return null;
         }
 
+        // Handle array shape types — per-key transformers (skip empty shapes from object mapping)
+        if ($targetType instanceof Type\ArrayShapeType && [] !== $targetType->getShape()) {
+            $fieldTransformers = [];
+            $sourceIsUntyped = isset($mapperMetadata->source)
+                && \in_array($mapperMetadata->source, ['array', \stdClass::class, LazyMap::class], true);
+
+            $sourceShape = $sourceType instanceof Type\ArrayShapeType ? $sourceType->getShape() : [];
+
+            foreach ($targetType->getShape() as $key => $field) {
+                $fieldTargetType = $field['type'];
+
+                if ($sourceIsUntyped) {
+                    // Use the mirrored source type from FromTargetMappingExtractor,
+                    // then override to mixed only for matching builtins (to force casts).
+                    $fieldSourceType = $sourceShape[$key]['type'] ?? Type::mixed();
+                    [$fieldSourceType] = $this->overrideSourceCollectionType($fieldSourceType, $fieldTargetType);
+                } else {
+                    $fieldSourceType = $fieldTargetType;
+                }
+
+                $newSource = $source->withType($fieldSourceType);
+                $newTarget = $target->withType($fieldTargetType);
+
+                $fieldTransformer = $this->chainTransformerFactory->getTransformer($newSource, $newTarget, $mapperMetadata);
+
+                if (null === $fieldTransformer) {
+                    return null;
+                }
+
+                $fieldTransformers[$key] = [
+                    'transformer' => $fieldTransformer,
+                    'optional' => $field['optional'],
+                ];
+            }
+
+            return new ArrayShapeTransformer($fieldTransformers);
+        }
+
         if (!$this->isCollectionType($sourceType) || !$this->isCollectionType($targetType)) {
             return null;
         }

--- a/tests/AutoMapperTest/ArraySourceCastShape/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastShape/expected.data
@@ -1,0 +1,8 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShape\Dto {
+  +profile: [
+    "active" => true
+    "age" => 30
+    "name" => "John"
+    "score" => 9.5
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShape/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastShape/map.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastShape;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array{name: string, age: int, score: float, active: bool} */
+    public array $profile;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'profile' => ['name' => 'John', 'age' => '30', 'score' => '9.5', 'active' => '1'],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.1.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.1.data
@@ -1,0 +1,7 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoNullableAndOptional {
+  +data: [
+    "age" => 30
+    "bio" => "Hello world"
+    "name" => "John"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.2.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.2.data
@@ -1,0 +1,7 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoNullableAndOptional {
+  +data: [
+    "age" => 25
+    "bio" => ""
+    "name" => "Jane"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.3.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.3.data
@@ -1,0 +1,6 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoNullableAndOptional {
+  +data: [
+    "age" => 40
+    "name" => "Bob"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.4.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.4.data
@@ -1,0 +1,16 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoNestedShapeWithCollection {
+  +data: [
+    "items" => [
+      AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\Tag {
+        +label: "a"
+      }
+      AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\Tag {
+        +label: "b"
+      }
+    ]
+    "meta" => [
+      "count" => 7
+      "title" => "Test"
+    ]
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.5.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.5.data
@@ -1,0 +1,8 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoDateTimeInShape {
+  +data: [
+    "created" => DateTimeImmutable @1736937000 {
+      date: 2025-01-15 10:30:00.0 +00:00
+    }
+    "label" => "event"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.6.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.6.data
@@ -1,0 +1,14 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoMixedDepth {
+  +data: [
+    "users" => [
+      [
+        "name" => "Alice"
+        "score" => 9.5
+      ]
+      [
+        "name" => "Bob"
+        "score" => 8.0
+      ]
+    ]
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/expected.data
@@ -1,0 +1,18 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\DtoObjectsAndScalars {
+  +data: [
+    "active" => true
+    "profile" => AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\Profile {
+      +name: "Alice"
+      +age: 28
+    }
+    "score" => 100
+    "tags" => [
+      AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\Tag {
+        +label: "php"
+      }
+      AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex\Tag {
+        +label: "symfony"
+      }
+    ]
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeComplex/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastShapeComplex/map.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeComplex;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Tag
+{
+    public string $label;
+}
+
+class Profile
+{
+    public string $name;
+    public int $age;
+}
+
+class DtoObjectsAndScalars
+{
+    /** @var array{profile: Profile, tags: array<Tag>, score: int, active: bool} */
+    public array $data;
+}
+
+class DtoNullableAndOptional
+{
+    /** @var array{name: string, bio?: ?string, age: int} */
+    public array $data;
+}
+
+class DtoNestedShapeWithCollection
+{
+    /** @var array{meta: array{title: string, count: int}, items: array<Tag>} */
+    public array $data;
+}
+
+class DtoDateTimeInShape
+{
+    /** @var array{label: string, created: \DateTimeInterface} */
+    public array $data;
+}
+
+class DtoMixedDepth
+{
+    /** @var array{users: array<array{name: string, score: float}>} */
+    public array $data;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    // 1. Object field + collection of objects + scalar casts
+    yield $autoMapper->map([
+        'data' => [
+            'profile' => ['name' => 'Alice', 'age' => 28],
+            'tags' => [['label' => 'php'], ['label' => 'symfony']],
+            'score' => '100',
+            'active' => '1',
+        ],
+    ], DtoObjectsAndScalars::class);
+
+    // 2. Nullable + optional field: present with value
+    yield $autoMapper->map([
+        'data' => ['name' => 'John', 'bio' => 'Hello world', 'age' => '30'],
+    ], DtoNullableAndOptional::class);
+
+    // 3. Nullable + optional field: present but null
+    yield $autoMapper->map([
+        'data' => ['name' => 'Jane', 'bio' => null, 'age' => '25'],
+    ], DtoNullableAndOptional::class);
+
+    // 4. Nullable + optional field: absent
+    yield $autoMapper->map([
+        'data' => ['name' => 'Bob', 'age' => '40'],
+    ], DtoNullableAndOptional::class);
+
+    // 5. Nested shape containing a collection of objects
+    yield $autoMapper->map([
+        'data' => [
+            'meta' => ['title' => 'Test', 'count' => '7'],
+            'items' => [['label' => 'a'], ['label' => 'b']],
+        ],
+    ], DtoNestedShapeWithCollection::class);
+
+    // 6. DateTime inside shape
+    yield $autoMapper->map([
+        'data' => ['label' => 'event', 'created' => '2025-01-15T10:30:00+00:00'],
+    ], DtoDateTimeInShape::class);
+
+    // 7. Collection of shapes (array<array{name: string, score: float}>)
+    yield $autoMapper->map([
+        'data' => [
+            'users' => [
+                ['name' => 'Alice', 'score' => '9.5'],
+                ['name' => 'Bob', 'score' => '8.0'],
+            ],
+        ],
+    ], DtoMixedDepth::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastShapeNested/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeNested/expected.data
@@ -1,0 +1,13 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeNested\Dto {
+  +data: [
+    "count" => 5
+    "tags" => [
+      "php"
+      "symfony"
+    ]
+    "user" => [
+      "age" => 28
+      "name" => "Alice"
+    ]
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeNested/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastShapeNested/map.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeNested;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array{user: array{name: string, age: int}, tags: array<string>, count: int} */
+    public array $data;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    yield $autoMapper->map([
+        'data' => [
+            'user' => ['name' => 'Alice', 'age' => '28'],
+            'tags' => ['php', 'symfony'],
+            'count' => '5',
+        ],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastShapeOptional/expected.1.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeOptional/expected.1.data
@@ -1,0 +1,6 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeOptional\Dto {
+  +profile: [
+    "age" => 25
+    "name" => "Jane"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeOptional/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeOptional/expected.data
@@ -1,0 +1,7 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeOptional\Dto {
+  +profile: [
+    "age" => 30
+    "name" => "John"
+    "nickname" => "Johnny"
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeOptional/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastShapeOptional/map.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeOptional;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class Dto
+{
+    /** @var array{name: string, nickname?: string, age: int} */
+    public array $profile;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    // With optional key present
+    yield $autoMapper->map([
+        'profile' => ['name' => 'John', 'nickname' => 'Johnny', 'age' => '30'],
+    ], Dto::class);
+
+    // Without optional key
+    yield $autoMapper->map([
+        'profile' => ['name' => 'Jane', 'age' => '25'],
+    ], Dto::class);
+})();

--- a/tests/AutoMapperTest/ArraySourceCastShapeTypedSource/expected.data
+++ b/tests/AutoMapperTest/ArraySourceCastShapeTypedSource/expected.data
@@ -1,0 +1,7 @@
+AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeTypedSource\TargetDto {
+  +data: [
+    "active" => true
+    "age" => 30
+    "score" => 9.5
+  ]
+}

--- a/tests/AutoMapperTest/ArraySourceCastShapeTypedSource/map.php
+++ b/tests/AutoMapperTest/ArraySourceCastShapeTypedSource/map.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoMapper\Tests\AutoMapperTest\ArraySourceCastShapeTypedSource;
+
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class SourceDto
+{
+    /** @var array{age: string, score: string, active: string} */
+    public array $data;
+}
+
+class TargetDto
+{
+    /** @var array{age: int, score: float, active: bool} */
+    public array $data;
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper();
+
+    $source = new SourceDto();
+    $source->data = ['age' => '30', 'score' => '9.5', 'active' => '1'];
+
+    yield $autoMapper->map($source, TargetDto::class);
+})();


### PR DESCRIPTION
Hi @joelwurtz,

#330 added casting for array<int> but that only works for homogeneous collections (one cast in a loop). Shapes like `array{name: string, age: int, score: float}` need a different approach since `ArrayShapeType::getCollectionValueType()` returns a union of all value types and loses the per-key info.

I added an ArrayShapeTransformer that generates per-key code instead of a uniform loop. Optional keys (nickname?) get an `array_key_exists` guard. Works with nested shapes, objects, DateTime, nullable fields, and collections inside shapes. Also handles object-to-object mapping when source and target shapes have different types.

Let me know if changes are needed. 