### PR TITLE
Fix "Undefined variable $existingValue" in generated collection mappers

### DIFF
--- a/src/Transformer/AbstractArrayTransformer.php
+++ b/src/Transformer/AbstractArrayTransformer.php
@@ -47,6 +47,15 @@ abstract readonly class AbstractArrayTransformer implements \Stringable, Transfo
         $existingValue = new Expr\Variable($uniqueVariableScope->getUniqueName('existingValue'));
         $assignByRef = $this->itemTransformer instanceof AssignedByReferenceTransformerInterface && $this->itemTransformer->assignByRef();
 
+        // Pre-compute $existingValue BEFORE the inner transformer is called: it consumes
+        // $existingValue (via withNewContext) and emitting the assignment afterwards
+        // produced "Undefined variable" warnings in PHP 8+.
+        if ($propertyMapping->target->readAccessor !== null && $this->itemTransformer instanceof IdentifierHashInterface) {
+            $hashValueTargetVariable = new Expr\Variable($uniqueVariableScope->getUniqueName('hashValueTarget'));
+            $itemStatements[] = new Stmt\Expression(new Expr\Assign($hashValueTargetVariable, $this->itemTransformer->getSourceHashExpression($loopValueVar)));
+            $itemStatements[] = new Stmt\Expression(new Expr\Assign($existingValue, new Expr\BinaryOp\Coalesce(new Expr\ArrayDimFetch($exisingValuesIndexed, $hashValueTargetVariable), new Expr\ConstFetch(new Name('null')))));
+        }
+
         /* Get the transform statements for the source property */
         [$output, $transformStatements] = $this->itemTransformer->transform($loopValueVar, $target, $propertyMapping, $uniqueVariableScope, $source, $existingValue);
 
@@ -89,12 +98,7 @@ abstract readonly class AbstractArrayTransformer implements \Stringable, Transfo
             }
 
             $mappedValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('mappedValue'));
-            $hashValueTargetVariable = new Expr\Variable($uniqueVariableScope->getUniqueName('hashValueTarget'));
 
-            if ($propertyMapping->target->readAccessor !== null && $this->itemTransformer instanceof IdentifierHashInterface) {
-                $itemStatements[] = new Stmt\Expression(new Expr\Assign($hashValueTargetVariable, $this->itemTransformer->getSourceHashExpression($loopValueVar)));
-                $itemStatements[] = new Stmt\Expression(new Expr\Assign($existingValue, new Expr\BinaryOp\Coalesce(new Expr\ArrayDimFetch($exisingValuesIndexed, $hashValueTargetVariable), new Expr\ConstFetch(new Name('null')))));
-            }
             $itemStatements[] = new Stmt\Expression(new Expr\Assign($mappedValueVar, $output));
             $itemStatements[] = new Stmt\If_(new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $mappedValueVar), [
                 'stmts' => [
@@ -132,10 +136,6 @@ abstract readonly class AbstractArrayTransformer implements \Stringable, Transfo
                         ]),
                     ],
                 ]);
-
-                $hashValueTargetVariable = new Expr\Variable($uniqueVariableScope->getUniqueName('hashValueTarget'));
-                $itemStatements[] = new Stmt\Expression(new Expr\Assign($hashValueTargetVariable, $this->itemTransformer->getSourceHashExpression($loopValueVar)));
-                $itemStatements[] = new Stmt\Expression(new Expr\Assign($existingValue, new Expr\BinaryOp\Coalesce(new Expr\ArrayDimFetch($exisingValuesIndexed, $hashValueTargetVariable), new Expr\ConstFetch(new Name('null')))));
             }
 
             $itemStatements[] = new Stmt\Expression($this->getAssignExpr($valuesVar, $output, $loopKeyVar, $assignByRef));

--- a/tests/AutoMapperTest/CollectionWithoutDeepPopulate/expected.data
+++ b/tests/AutoMapperTest/CollectionWithoutDeepPopulate/expected.data
@@ -1,0 +1,12 @@
+AutoMapper\Tests\AutoMapperTest\CollectionWithoutDeepPopulate\Target {
+  -items: [
+    AutoMapper\Tests\AutoMapperTest\CollectionWithoutDeepPopulate\TargetItem {
+      +id: 1
+      +label: "first"
+    }
+    AutoMapper\Tests\AutoMapperTest\CollectionWithoutDeepPopulate\TargetItem {
+      +id: 2
+      +label: "second"
+    }
+  ]
+}

--- a/tests/AutoMapperTest/CollectionWithoutDeepPopulate/map.php
+++ b/tests/AutoMapperTest/CollectionWithoutDeepPopulate/map.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Drop this file at:
+ *   tests/AutoMapperTest/CollectionWithoutDeepPopulate/map.php
+ *
+ * Then generate the expected dump:
+ *   UPDATE_FIXTURES=1 vendor/bin/phpunit --filter=testAutoMapperFixtures
+ *
+ * The fixture system in tests/AutoMapperTest.php::testAutoMapperFixtures
+ * picks it up automatically.
+ *
+ * Why it reproduces the bug:
+ *   - target has an adder/remover (addItem/removeItem) ->
+ *     AbstractArrayTransformer takes the `isAdderRemover()` branch
+ *   - source collection has 2 items -> the inner foreach body executes
+ *   - no `deep_target_to_populate` -> the existing target items are
+ *     not indexed, but $existingvalue is still read inside
+ *     withNewContext() before being assigned (root cause)
+ *
+ * On 10.2.0 / current main this raises:
+ *   Warning: Undefined variable $existingvalue
+ *
+ * After the patch the warning is gone and the dump matches expected.data.
+ *
+ * To catch the warning automatically in CI, set the PHPUnit config:
+ *   <phpunit failOnWarning="true" ...>
+ * (already the default in the repo's phpunit.xml.dist).
+ */
+
+namespace AutoMapper\Tests\AutoMapperTest\CollectionWithoutDeepPopulate;
+
+use AutoMapper\Attribute\MapFrom;
+use AutoMapper\Tests\AutoMapperBuilder;
+
+class SourceItem
+{
+    public int $id;
+    public string $label;
+}
+
+class Source
+{
+    /** @var SourceItem[] */
+    public array $items = [];
+}
+
+class TargetItem
+{
+    #[MapFrom(source: SourceItem::class, identifier: true)]
+    public int $id;
+
+    public string $label;
+}
+
+class Target
+{
+    /** @var TargetItem[] */
+    private array $items = [];
+
+    public function addItem(TargetItem $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    public function removeItem(TargetItem $item): void
+    {
+        foreach ($this->items as $key => $existing) {
+            if ($existing->id === $item->id) {
+                unset($this->items[$key]);
+                $this->items = array_values($this->items);
+                return;
+            }
+        }
+    }
+
+    /** @return TargetItem[] */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}
+
+return (function () {
+    $autoMapper = AutoMapperBuilder::buildAutoMapper(mapPrivatePropertiesAndMethod: true);
+
+    $source = new Source();
+
+    $a = new SourceItem();
+    $a->id = 1;
+    $a->label = 'first';
+
+    $b = new SourceItem();
+    $b->id = 2;
+    $b->label = 'second';
+
+    $source->items = [$a, $b];
+
+    // No `deep_target_to_populate` and no pre-existing target. Pre-patch:
+    // raises Warning: Undefined variable $existingvalue. Post-patch:
+    // clean mapping.
+    return $autoMapper->map($source, Target::class);
+})();


### PR DESCRIPTION
## Summary

Fixes a code-generation ordering bug in `AbstractArrayTransformer` that produces a `Warning: Undefined variable $existingValue` at runtime when mapping a non-empty collection of objects.

I must confess that Claude Code did this fix and PR. But it saved my life :D

## Reproduction

Given:

```php
class TargetItem
{
    public ?int $id = null;
}

class Target
{
    /** @var TargetItem[] */
    private array $items = [];

    public function getItems(): array        { return $this->items; }
    public function addItem(TargetItem $i): void   { $this->items[] = $i; }
    public function removeItem(TargetItem $i): void { /* ... */ }
}

class SourceItem
{
    public ?int $id = null;
}

class Source
{
    /** @var SourceItem[] */
    public array $items = [];
}
```

Mapping `$source` (with at least one element in `items`) to `Target` triggers:

```
Warning: Undefined variable $existingValue
  in var/cache/.../automapper/<...>.php
```

## Root cause

In [`AbstractArrayTransformer::transform()`](https://github.com/jolicode/automapper/blob/10.2.0/src/Transformer/AbstractArrayTransformer.php#L51) the inner item transformer is invoked first:

```php
[$output, $transformStatements] = $this->itemTransformer->transform(
    $loopValueVar, $target, $propertyMapping, $uniqueVariableScope, $source, $existingValue
);
$itemStatements = array_merge($itemStatements, $transformStatements);
```

`$existingValue` is passed to the inner `ObjectTransformer`, which emits it directly inside `MapperContext::withNewContext($context, '<prop>', $existingValue)` — because [`ArrayTransformerFactory`](https://github.com/jolicode/automapper/blob/10.2.0/src/Transformer/ArrayTransformerFactory.php#L61) (and `DoctrineCollectionTransformerFactory`) force `deepTargetToPopulate = false` on sub-items, which makes [`ObjectTransformer::transform()`](https://github.com/jolicode/automapper/blob/10.2.0/src/Transformer/ObjectTransformer.php#L65) take the `elseif ($existingValue !== null)` branch.

The assignment of `$existingValue` is then **appended** to `$itemStatements` later in both branches (`isAdderRemover` at L.91-97, regular collection at L.136-138). The generated code therefore looks like:

```php
foreach ($value->items ?? [] as $key => $value_1) {
    $mappedobjectorid =& $this->mappers['…']->map(
        $value_1,
        \AutoMapper\MapperContext::withNewContext($context, 'items', $existingvalue)   // <-- used here
    );
    $hashvaluetarget = $this->mappers['…']->getSourceHash($value_1);
    $existingvalue   = $existingvaluesindexed[$hashvaluetarget] ?? null;               // <-- assigned here
    ...
}
```

`$existingvalue` is read before being assigned → `Undefined variable` warning on every iteration.

The bug is masked when:
- the source collection is empty (loop body skipped), or
- the host application suppresses warnings (PHP 7-style behavior).

It is **not** masked under Symfony's dev error handler, which promotes warnings to exceptions and yields HTTP 500 on every POST/PUT that contains a non-empty embedded collection.

## Fix

Move the `$hashValueTargetVariable` / `$existingValue` assignment **before** the call to `$this->itemTransformer->transform()`. The condition (`readAccessor !== null && itemTransformer instanceof IdentifierHashInterface`) was already identical in both branches, so the two duplicated blocks are removed.

After the fix the generated code becomes:

```php
foreach ($value->items ?? [] as $key => $value_1) {
    $hashvaluetarget = $this->mappers['…']->getSourceHash($value_1);
    $existingvalue   = $existingvaluesindexed[$hashvaluetarget] ?? null;
    $mappedobjectorid =& $this->mappers['…']->map(
        $value_1,
        \AutoMapper\MapperContext::withNewContext($context, 'items', $existingvalue)
    );
    ...
}
```

## Test plan

- [ ] `vendor/bin/phpunit tests/AutoMapperTest.php --filter=Collection` (existing `DeepPopulateMergeExisting` fixture still passes — it covered the deep-populate case but didn't assert against warnings).
- [ ] Add a fixture under `tests/AutoMapperTest/CollectionWithoutDeepPopulate/` that maps an array to a target with adder/remover **without** `deep_target_to_populate => true` — reproduces the warning on `main` (10.2.0) and passes after the patch. Suggested skeleton in `tests/AutoMapperTest/CollectionWithoutDeepPopulate/map.php` (see attached `tests-skeleton-map.php`).
- [ ] Manual: regenerate any mapper that uses `AbstractArrayTransformer` (`bin/console cache:clear` if your loader's `reload_strategy` is `never`, you must delete `var/cache/<env>/automapper/Mapper_*.php` manually) and re-run a POST that carries a non-empty embedded collection. No more "Undefined variable" warning.

## Notes

- The change is purely a reordering of emitted statements; the resulting variables are still scoped to the foreach body, so generated mappers stay byte-equivalent except for the line ordering inside the loop.
- The same defect existed in the `else` branch of `AbstractArrayTransformer` (non-adder/remover collections). It rarely surfaced because most non-adder targets either re-assign the whole array or don't pass through `ObjectTransformer` with `deepTargetToPopulate=false`, but the fix covers both paths.
